### PR TITLE
Update default M from 2 to 8

### DIFF
--- a/src/utils/matmul_helper.h
+++ b/src/utils/matmul_helper.h
@@ -32,7 +32,7 @@
 #include <map>
 #include <tuple>
 
-#define USE_AMX_M 2
+#define USE_AMX_M 8
 
 class MMHelper {
 public:


### PR DESCRIPTION
So when matrix M<=8, we will use ig kernel to boost bf16 gemms, otherwise use oneDNN kernel.
From the performance data， we can see that with M=8， It can boost next token performance of BS=4/8, especially for BS=4.
This patch doesn't affect first token latency since the M of first latency is larger than 8.


<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
</head>

<body link="#0563C1" vlink="#954F72">



batchsize | 1 | 2 | 4 | 8 | 16
-- | -- | -- | -- | -- | --
chatglm-6b
original M=2 | 30.58 | 31.03 | 63.56 | 67.61 | 78.38
M=7 | 29.54 | 32.58 | 41.28 | 68.14 | 78.2
M=8 | 29.87 | 32.88 | 40.57 | 66.82 | 78.83
  |   |   |   |   |  
chatglm2-6b
original M=2 | 30.7 | 31.61 | 63.11 | 67.32 | 83.61
M=7 | 29.94 | 33.3 | 41.1 | 70.68 | 83.49
M=8 | 31.76 | 31.84 | 41.01 | 63.84 | 78.83
  |   |   |   |   |  
llama-7b
original M=2 | 32.38 | 36.47 | 71.6 | 78.45 | 92.83
M=7 | 33.88 | 37.54 | 46.43 | 79.64 | 93.27
M=8 | 32.64 | 36.59 | 46.04 | 75.14 | 93.18



</body>

</html>
