### PR TITLE
Make configured max token size work

### DIFF
--- a/src/layers/attention.h
+++ b/src/layers/attention.h
@@ -33,7 +33,7 @@
 template <typename WeiT, typename QKPO_CLS, typename NORM_CLS, bool INPUT_AS_RESID = true>
 class Attention {
 public:
-    Attention(int layerId, DecoderContext *ctx) : layerId(layerId), qkpo(ctx->attHeadSize) {
+    Attention(int layerId, DecoderContext *ctx) : layerId(layerId), qkpo(ctx->attHeadSize, ctx->maxPositions) {
         // Group attention or multi-head attention (multi-head attn is a special case of group attn)
         if (ctx->attHeadNum % ctx->kvHeadNum == 0) {
             // We are responsible for the range [startQHead, endQHead)

--- a/src/models/common_decoder.h
+++ b/src/models/common_decoder.h
@@ -35,7 +35,7 @@
 using namespace xft;
 
 struct QKPO_Dummy {
-    QKPO_Dummy(int dim) {}
+    QKPO_Dummy(int dim, int maxPos) {}
     void forward(float *query, float *key, int qStride, int kStride, const int *qk_shape, const int *position_ids) {}
 };
 


### PR DESCRIPTION
pass the max position info to QKPO class (which is the positional embedding), to make sure the positional embedding table is big enough.