### PR TITLE
[perf] improve next token latency when (#threads >= 2 * #heads) by sharding the head into multiple splits

### DIFF
--- a/src/common/aligned_type.h
+++ b/src/common/aligned_type.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+template <typename T, std::size_t Alignment>
+struct AlignedType {
+    alignas(Alignment) T data;
+
+    // Default constructor
+    AlignedType() = default;
+
+    // Constructor to initialize with a value of type T
+    explicit AlignedType(const T& value) : data(value) {}
+
+    // Conversion operator to convert AlignedType to T
+    operator T() const {
+        return data;
+    }
+
+    // Overload the assignment operator to assign a value of type T
+    AlignedType& operator=(const T& value) {
+        data = value;
+        return *this;
+    }
+};

--- a/src/common/aligned_type.h
+++ b/src/common/aligned_type.h
@@ -11,15 +11,13 @@ struct AlignedType {
     AlignedType() = default;
 
     // Constructor to initialize with a value of type T
-    explicit AlignedType(const T& value) : data(value) {}
+    explicit AlignedType(const T &value) : data(value) {}
 
     // Conversion operator to convert AlignedType to T
-    operator T() const {
-        return data;
-    }
+    operator T() const { return data; }
 
     // Overload the assignment operator to assign a value of type T
-    AlignedType& operator=(const T& value) {
+    AlignedType &operator=(const T &value) {
         data = value;
         return *this;
     }

--- a/src/utils/decoder_util.h
+++ b/src/utils/decoder_util.h
@@ -493,13 +493,13 @@ public:
     }
 
     template <typename T, typename Tt>
-    static void arrayCpy(T* dst, const Tt* src, int n) {
+    static void arrayCpy(T *dst, const Tt *src, int n) {
 #pragma omp simd
         for (int i = 0; i < n; i++) {
             dst[i] = static_cast<T>(src[i]);
         }
     }
-    
+
     // batchs x seqlen x 3 x head x heads ->  3 x batchs x head x seqlen x heads (2
     // 0 3 1 4)
     template <typename T, typename Tt>
@@ -510,46 +510,37 @@ public:
         int hiddenQKVSize = hiddenQSize + hiddenKVSize * 2;
 
         int blockSize = hiddenQKVSize * seqLen;
-    
+
         const T *qBuffer = qkvBuffer;
         const T *kBuffer = qkvBuffer + hiddenQSize;
         const T *vBuffer = qkvBuffer + hiddenQSize + hiddenKVSize;
-    
+
         Tt *qTransBuffer = qkvTransBuffer;
         Tt *kTransBuffer = qkvTransBuffer + batchSize * hiddenQSize * seqLen;
         Tt *vTransBuffer = qkvTransBuffer + batchSize * (hiddenQSize + hiddenKVSize) * seqLen;
-    
+
 #pragma omp parallel for collapse(3)
         for (int i = 0; i < batchSize; i++) {
             for (int k = 0; k < headQNum; k++) { // assume headQNum >= headKVNum
                 for (int j = 0; j < seqLen; j++) {
-                    const float *qSrcEachBatch =
-                        reinterpret_cast<const T*>(qBuffer) + blockSize * i;
-                    const float *kSrcEachBatch =
-                        reinterpret_cast<const T*>(kBuffer) + blockSize * i;
-                    const float *vSrcEachBatch =
-                        reinterpret_cast<const T*>(vBuffer) + blockSize * i;
-    
+                    const float *qSrcEachBatch = reinterpret_cast<const T *>(qBuffer) + blockSize * i;
+                    const float *kSrcEachBatch = reinterpret_cast<const T *>(kBuffer) + blockSize * i;
+                    const float *vSrcEachBatch = reinterpret_cast<const T *>(vBuffer) + blockSize * i;
+
                     int dstOffEachHead = k * seqLen * headSize;
                     int srcOffEachLine = k * headSize;
-    
+
                     int dstOffEachLine = j * headSize;
                     int srcOffEachHead = j * hiddenQKVSize;
-    
-                    Tt *qDstEachLine = qTransBuffer + i * hiddenQSize * seqLen +
-                                          dstOffEachHead + dstOffEachLine;
-                    const T* qSrcEachLine =
-                        qSrcEachBatch + srcOffEachHead + srcOffEachLine;
-    
-                    Tt *kDstEachLine = kTransBuffer + i * hiddenKVSize * seqLen +
-                                          dstOffEachHead + dstOffEachLine;
-                    const T *kSrcEachLine =
-                        kSrcEachBatch + srcOffEachHead + srcOffEachLine;
-    
-                    Tt *vDstEachLine = vTransBuffer + i * hiddenKVSize * seqLen +
-                                          dstOffEachHead + dstOffEachLine;
-                    const T *vSrcEachLine =
-                        vSrcEachBatch + srcOffEachHead + srcOffEachLine;
+
+                    Tt *qDstEachLine = qTransBuffer + i * hiddenQSize * seqLen + dstOffEachHead + dstOffEachLine;
+                    const T *qSrcEachLine = qSrcEachBatch + srcOffEachHead + srcOffEachLine;
+
+                    Tt *kDstEachLine = kTransBuffer + i * hiddenKVSize * seqLen + dstOffEachHead + dstOffEachLine;
+                    const T *kSrcEachLine = kSrcEachBatch + srcOffEachHead + srcOffEachLine;
+
+                    Tt *vDstEachLine = vTransBuffer + i * hiddenKVSize * seqLen + dstOffEachHead + dstOffEachLine;
+                    const T *vSrcEachLine = vSrcEachBatch + srcOffEachHead + srcOffEachLine;
                     arrayCpy<Tt, T>(qDstEachLine, qSrcEachLine, headSize);
                     if (k < headKVNum) {
                         arrayCpy<Tt, T>(kDstEachLine, kSrcEachLine, headSize);
@@ -559,40 +550,37 @@ public:
             }
         }
     }
-    
+
     // batchs x head x seqlen x heads -> batchs x seqlen x head x heads (0 2 1 3)
     template <typename T, typename Tt>
-    static void transposeAttnResult(T *Buffer, Tt *TransBuffer, int batchSize, int seqLen, int headNum,
-            int headSize, int dstStride) {
+    static void transposeAttnResult(
+            T *Buffer, Tt *TransBuffer, int batchSize, int seqLen, int headNum, int headSize, int dstStride) {
         int hiddenSize = headNum * headSize;
-        int blockSize = seqLen * hiddenSize;  // dst buffer stride in each batch
-    
+        int blockSize = seqLen * hiddenSize; // dst buffer stride in each batch
+
 #pragma omp parallel for collapse(2)
         for (int i = 0; i < batchSize; i++) {
             for (int k = 0; k < seqLen; k++) {
                 int srcOffEachHead = k * headSize;
                 int dstOffEachLine = k * dstStride;
-    
+
                 for (int j = 0; j < headNum; j++) {
                     int srcOffEachLine = j * seqLen * headSize;
                     int dstOffEachHead = j * headSize;
-    
-                    Tt *qDstEachLine = TransBuffer + dstOffEachHead +
-                                  dstOffEachLine + i * seqLen * dstStride;
-                    const T *qSrcEachLine = Buffer + srcOffEachLine +
-                                       srcOffEachHead + i * blockSize;
-    
+
+                    Tt *qDstEachLine = TransBuffer + dstOffEachHead + dstOffEachLine + i * seqLen * dstStride;
+                    const T *qSrcEachLine = Buffer + srcOffEachLine + srcOffEachHead + i * blockSize;
+
                     arrayCpy<Tt, T>(qDstEachLine, qSrcEachLine, headSize);
                 }
             }
         }
     }
-    
+
     // C = A * B
     // bTranspose: B need to be transposed or not
     // xdnn_sgemm_single_thread(transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
-    static void sgemm(const float* A, const float* B, float* C, int m, int n, int k,
-            bool transa, bool transb) {
+    static void sgemm(const float *A, const float *B, float *C, int m, int n, int k, bool transa, bool transb) {
         int lda = (transa ? m : k);
         int ldb = (transb ? k : n);
         int ldc = n;
@@ -602,18 +590,18 @@ public:
         char tb[] = "N";
         if (transa) ta[0] = 'T';
         if (transb) tb[0] = 'T';
-    
+
         dnnl_sgemm(ta[0], tb[0], m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
     }
-    
+
     // need to do for res.
     static void softmaxTile(float *AB, float *sum, float *max, float *preSum, float *preMax, float refac,
             const float *attnMask, int m, int k, int attnMskStride) {
         float maxVal = std::numeric_limits<float>::lowest();
         __m512 vrefac = _mm512_set1_ps(refac);
         for (int i = 0; i < m; ++i) {
-            float* buf = AB + i * k;
-            const float* attnMsk = attnMask + i * attnMskStride;
+            float *buf = AB + i * k;
+            const float *attnMsk = attnMask + i * attnMskStride;
             // max val for avoiding inf and nan
             __m512 vmax = _mm512_set1_ps(maxVal);
             for (int off = 0; off < k; off += 16) {
@@ -621,16 +609,16 @@ public:
                 __mmask16 mask = (remain >= 16 ? 0xffff : (1 << remain) - 1);
                 __m512 vx = _mm512_maskz_loadu_ps(mask, buf + off);
                 __m512 vmask = _mm512_maskz_loadu_ps(mask, attnMsk + off);
-        
+
                 vmax = _mm512_mask_max_ps(vmax, mask, vmax, vx * vrefac + vmask);
             }
             float _max = _mm512_reduce_max_ps(vmax);
-        
+
             _max = _max > max[i] ? _max : max[i];
             __m512 merr = _mm512_set1_ps(max[i] - _max);
             merr = BertUtil::vexp(merr);
             max[i] = _max;
-        
+
             // exp and get sum
             __m512 vsum = _mm512_set1_ps(0);
             vmax = _mm512_set1_ps(_max);
@@ -650,26 +638,26 @@ public:
             float fac = _mm512_cvtss_f32(merr);
             sum[i] = sum[i] * fac + _sum;
             _sum = sum[i];
-        
+
             // Compute exp/sum(exp) and store
             __m512 vrsum = _mm512_set1_ps(1.0f / _sum);
             for (int off = 0; off < k; off += 16) {
                 int remain = k - off;
                 __mmask16 mask = (remain >= 16 ? 0xffff : (1 << remain) - 1);
-        
+
                 __m512 vx = _mm512_maskz_loadu_ps(mask, buf + off);
                 vx = vx * vrsum;
-        
+
                 _mm512_mask_storeu_ps(buf + off, mask, vx);
             }
         }
     }
-    
-    static void updateOutTile(float* output, const float* expABC, float* preSum, float* sum, float* preMax,
-            float* max, int m, int n) {
+
+    static void updateOutTile(
+            float *output, const float *expABC, float *preSum, float *sum, float *preMax, float *max, int m, int n) {
         for (int i = 0; i < m; ++i) {
-            const float* buf = expABC + i * n;
-            float* outbuf = output + i * n;
+            const float *buf = expABC + i * n;
+            float *outbuf = output + i * n;
             __m512 merr = _mm512_set1_ps(preMax[i] - max[i]);
             merr = BertUtil::vexp(merr);
             __m512 vfac = _mm512_set1_ps(preSum[i] / sum[i]);
@@ -685,18 +673,17 @@ public:
             preMax[i] = max[i];
         }
     }
-    
+
     // hard code: axis = 1
     // sum += sum(exp(A[i]))
     // output = output * preSum / sum + (exp(A) / sum) x B
     // preSum = sum
-    static void incrementalTileAttention(const float* A, const float* B, const float* C, const float* attnMask,
-            int m, int n, int k, int attnMskStride, float* preSum, float* sum, float* preMax, float* max,
-            float refac, float* AB, float* expABC, float* output) {
+    static void incrementalTileAttention(const float *A, const float *B, const float *C, const float *attnMask, int m,
+            int n, int k, int attnMskStride, float *preSum, float *sum, float *preMax, float *max, float refac,
+            float *AB, float *expABC, float *output) {
         sgemm(A, B, AB, m, k, n, false, true);
         softmaxTile(AB, sum, max, preSum, preMax, refac, attnMask, m, k, attnMskStride);
         sgemm(AB, C, expABC, m, n, k, false, false);
         updateOutTile(output, expABC, preSum, sum, preMax, max, m, n);
     }
-    
 };

--- a/src/utils/simple_mem_pool.h
+++ b/src/utils/simple_mem_pool.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <iostream>
-#include <unordered_map>
-#include <string>
 #include <cstdlib>
+#include <iostream>
+#include <string>
+#include <unordered_map>
 
 class SimpleMemPool {
 private:
-    std::unordered_map<std::string, std::pair<void*, size_t>> memoryMap;
+    std::unordered_map<std::string, std::pair<void *, size_t>> memoryMap;
 
     // Private constructor to enforce Singleton pattern
     SimpleMemPool() {}
@@ -17,13 +17,13 @@ private:
 
 public:
     // Static method to get the singleton instance
-    static SimpleMemPool& instance() {
+    static SimpleMemPool &instance() {
         static SimpleMemPool memManager;
         return memManager;
     }
 
     // Allocate or reallocate memory buffer based on name and size
-    void* getBuffer(const std::string& name, size_t size, size_t alignment = 64) {
+    void *getBuffer(const std::string &name, size_t size, size_t alignment = 64) {
         auto it = memoryMap.find(name);
 
         if (it != memoryMap.end()) {
@@ -38,7 +38,7 @@ public:
         }
 
         // Allocate new aligned buffer
-        void* buffer = aligned_alloc(alignment, size);
+        void *buffer = aligned_alloc(alignment, size);
         if (buffer == nullptr) {
             // Allocation failed
             std::cerr << "Memory allocation failed for buffer: " << name << std::endl;
@@ -53,7 +53,7 @@ public:
 
     // Destructor to free all allocated memory on program termination
     ~SimpleMemPool() {
-        for (auto& entry : memoryMap) {
+        for (auto &entry : memoryMap) {
             free(entry.second.first);
         }
         memoryMap.clear();

--- a/src/utils/simple_mem_pool.h
+++ b/src/utils/simple_mem_pool.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <iostream>
+#include <unordered_map>
+#include <string>
+#include <cstdlib>
+
+class SimpleMemPool {
+private:
+    std::unordered_map<std::string, std::pair<void*, size_t>> memoryMap;
+
+    // Private constructor to enforce Singleton pattern
+    SimpleMemPool() {}
+
+    SimpleMemPool(const SimpleMemPool &mgr) = delete;
+    SimpleMemPool &operator=(const SimpleMemPool &mgr) = delete;
+
+public:
+    // Static method to get the singleton instance
+    static SimpleMemPool& instance() {
+        static SimpleMemPool memManager;
+        return memManager;
+    }
+
+    // Allocate or reallocate memory buffer based on name and size
+    void* getBuffer(const std::string& name, size_t size, size_t alignment = 64) {
+        auto it = memoryMap.find(name);
+
+        if (it != memoryMap.end()) {
+            // Buffer with the given name found
+            if (it->second.second >= size) {
+                // Existing buffer size is sufficient, return it
+                return it->second.first;
+            } else {
+                // Reallocate the buffer
+                free(it->second.first);
+            }
+        }
+
+        // Allocate new aligned buffer
+        void* buffer = aligned_alloc(alignment, size);
+        if (buffer == nullptr) {
+            // Allocation failed
+            std::cerr << "Memory allocation failed for buffer: " << name << std::endl;
+            exit(-1);
+        }
+
+        // Update or insert entry in the mapping
+        memoryMap[name] = std::make_pair(buffer, size);
+
+        return buffer;
+    }
+
+    // Destructor to free all allocated memory on program termination
+    ~SimpleMemPool() {
+        for (auto& entry : memoryMap) {
+            free(entry.second.first);
+        }
+        memoryMap.clear();
+    }
+};


### PR DESCRIPTION
Command: XFT_FAKE_MODEL=1 OMP_NUM_THREADS=32 mpirun -n 1 numactl -N 0 -m 0 ./build/example -m examples/model_config/llama-2-7b/ -t examples/model_config/llama-2-7b/tokenizer.model -d fp16 -l 1024 --output_len 10 --loop 10  : -n 1 numactl -N 1 -m 1 ./build/example -m examples/model_config/llama-2-7b/ -t examples/model_config/llama-2-7b/tokenizer.model -d fp16 -l 1024 --output_len 10 --loop 10
Server: a develop machine (perf may be not good)
Perf: ~40->~39ms