### PR TITLE
[Tools] Add convert tools in xft.

### DIFF
--- a/src/xfastertransformer/tools/__init__.py
+++ b/src/xfastertransformer/tools/__init__.py
@@ -12,15 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ============================================================================
-import torch
-import os
 
-torch.classes.load_library(os.path.dirname(os.path.abspath(__file__)) + "/libxfastertransformer_pt.so")
-
-from .automodel import AutoModel
-
-from .tools import LlamaConvert
-from .tools import ChatGLMConvert
-from .tools import ChatGLM2Convert
-from .tools import OPTConvert
-from .tools import BaichuanConvert
+from .llama_convert import LlamaConvert
+from .chatglm_convert import ChatGLMConvert
+from .chatglm2_convert import ChatGLM2Convert
+from .opt_convert import OPTConvert
+from .baichuan_convert import BaichuanConvert

--- a/src/xfastertransformer/tools/baichuan_convert.py
+++ b/src/xfastertransformer/tools/baichuan_convert.py
@@ -1,0 +1,186 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import configparser
+import multiprocessing
+import numpy as np
+import os
+
+from transformers import AutoModelForCausalLM
+
+from .convert import BaseModelConvert
+
+
+class BaichuanConvert(BaseModelConvert):
+    """
+    Convert huggingface Baichuan model. Use https://huggingface.co/baichuan-inc
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def split_and_convert_process(self, i, saved_dir, factor, key, val):
+        def save_val(val, key, tp_num=None):
+            if key.startswith("model."):
+                path = os.path.join(saved_dir, key)
+            else:
+                path = os.path.join(saved_dir, "model." + key)
+
+            if tp_num is not None:
+                path += "." + str(tp_num)
+            path += ".bin"
+
+            val.tofile(path)
+
+        if (
+            "input_layernorm.weight" in key
+            or "input_layernorm.bias" in key
+            or "attention.dense.bias" in key
+            or "post_attention_layernorm.weight" in key
+            or "post_attention_layernorm.bias" in key
+            or "mlp.dense_4h_to_h.bias" in key
+            or "final_layernorm.weight" in key
+            or "final_layernorm.bias" in key
+        ):
+            # shared weights, only need to convert the weights of rank 0
+            if i == 0:
+                save_val(val, key)
+
+        elif "mlp.gate_proj.weight" in key or "mlp.up_proj.weight" in key or "mlp.down_proj.weight" in key:
+            split_vals = np.split(val, factor, axis=0)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "attention.query_key_value.weight" in key:
+            hidden_dim = val.shape[0]
+            local_dim = (int)(val.shape[-1] / 3)
+
+            val = val.reshape(hidden_dim, 3, local_dim)
+
+            split_vals = np.split(val, factor, axis=-1)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "attention.dense.weight" in key:
+            split_vals = np.split(val, factor, axis=0)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        else:
+            print("[ERROR] cannot find key '{}'".format(key))
+
+    def split_and_convert(self, input_dir, output_dir, dtype, processes):
+        # create directory if not exist
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        # load the model
+        model = AutoModelForCausalLM.from_pretrained(input_dir, device_map="auto", trust_remote_code=True)
+
+        hf_config = vars(model.config)
+
+        # save parameters to config file
+        config = configparser.ConfigParser()
+        config["baichuan"] = {}
+        has_post_decoder_layernorm = True
+        try:
+            config["baichuan"]["model_name"] = (
+                "baichuan" if hf_config["_name_or_path"] == "" else hf_config["_name_or_path"]
+            )
+            config["baichuan"]["head_num"] = str(hf_config["num_attention_heads"])
+            hidden_size = hf_config["hidden_size"]
+            config["baichuan"]["size_per_head"] = str(hidden_size // hf_config["num_attention_heads"])
+            config["baichuan"]["inter_size"] = str(hf_config["intermediate_size"])
+            config["baichuan"]["max_pos_seq_len"] = str(hf_config.get("max_position_embeddings", 0))
+            config["baichuan"]["model_max_length"] = str(
+                hf_config.get("model_max_length", config["baichuan"]["max_pos_seq_len"])
+            )
+            config["baichuan"]["num_layer"] = str(hf_config["num_hidden_layers"])
+            config["baichuan"]["rms_norm_eps"] = "1e-6"
+            config["baichuan"]["layernorm_type"] = "pre_layernorm"
+            config["baichuan"]["activation_type"] = "silu"
+            config["baichuan"]["has_post_decoder_layernorm"] = "1" if has_post_decoder_layernorm else "0"
+            config["baichuan"]["vocab_size"] = str(hf_config["vocab_size"])
+            config["baichuan"]["start_id"] = str(hf_config["bos_token_id"])
+            config["baichuan"]["end_id"] = str(hf_config["eos_token_id"])
+            config["baichuan"]["weight_data_type"] = dtype
+            with open(os.path.join(output_dir, "config.ini"), "w") as configfile:
+                config.write(configfile)
+        except Exception as e:
+            print("Fail to save the config in config.ini.", str(e))
+
+        hf_model_name_pattern = [
+            "input_layernorm.weight",
+            "self_attn.W_pack.weight",
+            "self_attn.o_proj.weight",
+            "post_attention_layernorm.weight",
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+            "mlp.down_proj.weight",
+        ]
+
+        ft_model_name_pattern = [
+            "input_layernorm.weight",
+            "attention.query_key_value.weight",
+            "attention.dense.weight",
+            "post_attention_layernorm.weight",
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+            "mlp.down_proj.weight",
+        ]
+
+        state_dict = model.state_dict()
+        model_named_parameters = dict()
+        for name, param in state_dict.items():
+            print(name)
+            if "embed" in name:
+                model_named_parameters[name] = param
+            elif "lm_head" in name:
+                model_named_parameters[name] = param
+            else:
+                model_named_parameters[name] = param.permute(1, 0) if len(param.shape) == 2 else param
+
+        pool = multiprocessing.Pool(processes)
+        for name, param in model_named_parameters.items():
+            if name == "model.embed_tokens.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(os.path.join(output_dir, "model.wte.bin"))
+            elif name == "model.norm.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.final_layernorm.weight.bin")
+                )
+            # elif name == 'model.final_layernorm.bias':
+            #     param.detach().cpu().numpy().astype(self.dtype).tofile(
+            #         os.path.join(output_dir, "model.final_layernorm.bias.bin"))
+            elif name == "lm_head.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.lm_head.weight.bin")
+                )
+            else:
+                starmap_args = []
+                for i in range(len(hf_model_name_pattern)):
+                    if hf_model_name_pattern[i] in name:
+                        factor = 1
+                        new_name = name.replace(hf_model_name_pattern[i], ft_model_name_pattern[i])
+                        starmap_args.append(
+                            (
+                                0,
+                                output_dir,
+                                factor,
+                                new_name,
+                                param.detach().cpu().numpy().astype(self.dtype),
+                            )
+                        )
+                pool.starmap_async(self.split_and_convert_process, starmap_args)
+        pool.close()
+        pool.join()

--- a/src/xfastertransformer/tools/chatglm2_convert.py
+++ b/src/xfastertransformer/tools/chatglm2_convert.py
@@ -1,0 +1,244 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+import configparser
+import multiprocessing
+import numpy as np
+import os
+
+from transformers import AutoModel
+
+from .convert import BaseModelConvert
+
+
+class ChatGLM2Convert(BaseModelConvert):
+    """
+    Convert huggingface ChatGLM model. Use https://huggingface.co/THUDM/chatglm2-6b
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def split_and_convert_process(
+        self,
+        i,
+        saved_dir,
+        factor,
+        key,
+        val,
+        num_attention_heads,
+        multi_query_group_num,
+        kv_channels,
+    ):
+        def save_val(val, key, tp_num=None):
+            path = path = os.path.join(saved_dir, "model." + key)
+            if tp_num is not None:
+                path += "." + str(tp_num)
+            path += ".bin"
+
+            val.tofile(path)
+
+        if (
+            "input_layernorm.weight" in key
+            or "input_layernorm.bias" in key
+            or "attention.dense.bias" in key
+            or "post_attention_layernorm.weight" in key
+            or "post_attention_layernorm.bias" in key
+            or "mlp.dense_4h_to_h.bias" in key
+            or "final_layernorm.weight" in key
+            or "final_layernorm.bias" in key
+        ):
+            # shared weights, only need to convert the weights of rank 0
+            if i == 0:
+                save_val(val, key)
+
+        elif "attention.dense.weight" in key or "mlp.dense_4h_to_h.weight" in key:
+            split_vals = np.split(val, factor, axis=0)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "mlp.dense_h_to_4h.weight" in key or "mlp.dense_h_to_4h.bias" in key:
+            split_vals = np.split(val, factor, axis=-1)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "attention.query_key_value.bias" in key:
+            hidden_dim = val.shape[0]
+            qcol = int(num_attention_heads)
+            kcol = int(multi_query_group_num)
+            vcol = int(multi_query_group_num)
+            kv_channels = int(kv_channels)
+            qkv = np.split(val, [qcol, qcol + kcol])
+            q = qkv[0]  # .reshape(1, qcol * kv_channels)
+            k = qkv[1]  # .reshape(1, kcol * kv_channels)
+            v = qkv[2]  # .reshape(1, vcol * kv_channels)
+            q_split_vals = np.split(q, factor, axis=-1)
+            k_split_vals = np.split(k, factor, axis=-1)
+            v_split_vals = np.split(v, factor, axis=-1)
+            for j in range(factor):
+                val = np.concatenate((q_split_vals[j], k_split_vals[j], v_split_vals[j]), axis=-1)
+                save_val(val, key, i * factor + j)
+
+        elif "attention.query_key_value.weight" in key:
+            hidden_dim = val.shape[0]
+            kv_channels = int(kv_channels)
+            qcol = int(num_attention_heads) * kv_channels
+            kcol = int(multi_query_group_num) * kv_channels
+            vcol = int(multi_query_group_num) * kv_channels
+            # val = val.reshape(hidden_dim, kv_channels, (qcol + kcol + vcol))
+            qkv = np.split(val, [qcol, (qcol + kcol)], axis=-1)
+            q = qkv[0]  # .reshape(hidden_dim, qcol * kv_channels)
+            k = qkv[1]  # .reshape(hidden_dim, kcol * kv_channels)
+            v = qkv[2]  # .reshape(hidden_dim, vcol * kv_channels)
+            # val = np.concatenate((q, k, v), axis=-1)
+            q_split_vals = np.split(q, factor, axis=-1)
+            k_split_vals = np.split(k, factor, axis=-1)
+            v_split_vals = np.split(v, factor, axis=-1)
+            for j in range(factor):
+                val = np.concatenate((q_split_vals[j], k_split_vals[j], v_split_vals[j]), axis=-1)
+                save_val(val, key, i * factor + j)
+
+        else:
+            print("[ERROR] cannot find key '{}'".format(key))
+
+    def split_and_convert(self, input_dir, output_dir, dtype, processes):
+        # create directory if not exist
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        # load the model
+        model = AutoModel.from_pretrained(input_dir, trust_remote_code=True)
+
+        hf_config = vars(model.config)
+        print("hf_config= {}".format(hf_config))
+
+        layer_names = [name for name, param in model.named_parameters()]
+
+        # save parameters to config file
+        config = configparser.ConfigParser()
+        config["chatglm2"] = {}
+        has_post_decoder_layernorm = "model.decoder.final_layer_norm.bias" in layer_names
+        try:
+            config["chatglm2"]["model_name"] = (
+                "chatglm2" if hf_config["_name_or_path"] == "" else hf_config["_name_or_path"]
+            )
+            num_attention_heads = config["chatglm2"]["head_num"] = str(hf_config["num_attention_heads"])
+            n_embd = hf_config["hidden_size"]
+            config["chatglm2"]["size_per_head"] = str(n_embd // hf_config["num_attention_heads"])
+            config["chatglm2"]["inter_size"] = str(hf_config["ffn_hidden_size"])
+            config["chatglm2"]["max_pos_seq_len"] = str(hf_config["seq_length"])
+            config["chatglm2"]["num_layer"] = str(hf_config["num_layers"])
+            config["chatglm2"]["layernorm_eps"] = str(hf_config["layernorm_epsilon"])  # "1e-5"
+            config["chatglm2"]["layernorm_type"] = "pre_layernorm"
+            config["chatglm2"]["activation_type"] = "swiglu"
+            config["chatglm2"]["has_post_decoder_layernorm"] = (
+                "1" if str(hf_config["post_layer_norm"]) == "True" else "0"
+            )
+            config["chatglm2"]["vocab_size"] = str(hf_config["padded_vocab_size"])
+            config["chatglm2"]["start_id"] = str(hf_config["bos_token_id"])
+            config["chatglm2"]["end_id"] = str(hf_config["eos_token_id"])
+            config["chatglm2"]["weight_data_type"] = dtype
+
+            kv_channels = config["chatglm2"]["kv_channels"] = str(hf_config["kv_channels"])
+            config["chatglm2"]["rmsnorm"] = "1" if str(hf_config["rmsnorm"]) == "True" else "0"
+            config["chatglm2"]["apply_residual_connection_post_layernorm"] = (
+                "1" if str(hf_config["apply_residual_connection_post_layernorm"]) == "True" else "0"
+            )
+            config["chatglm2"]["multi_query_attention"] = (
+                "1" if str(hf_config["multi_query_attention"]) == "True" else "0"
+            )
+            multi_query_group_num = config["chatglm2"]["kv_head_num"] = str(hf_config["multi_query_group_num"])
+            config["chatglm2"]["pad_id"] = str(hf_config["pad_token_id"])
+
+            with open(os.path.join(output_dir, "config.ini"), "w") as configfile:
+                config.write(configfile)
+        except Exception as e:
+            print("Fail to save the config in config.ini.", str(e))
+
+        huggingface_model_name_pattern = [
+            "input_layernorm.bias",  #
+            "input_layernorm.weight",
+            "self_attention.query_key_value.bias",
+            "self_attention.query_key_value.weight",
+            "self_attention.dense.bias",  #
+            "self_attention.dense.weight",
+            "post_attention_layernorm.bias",  #
+            "post_attention_layernorm.weight",
+            "mlp.dense_h_to_4h.bias",  #
+            "mlp.dense_h_to_4h.weight",
+            "mlp.dense_4h_to_h.bias",  #
+            "mlp.dense_4h_to_h.weight",
+        ]
+
+        ft_model_name_pattern = [
+            "input_layernorm.bias",
+            "input_layernorm.weight",
+            "attention.query_key_value.bias",
+            "attention.query_key_value.weight",
+            "attention.dense.bias",
+            "attention.dense.weight",
+            "post_attention_layernorm.bias",
+            "post_attention_layernorm.weight",
+            "mlp.dense_h_to_4h.bias",
+            "mlp.dense_h_to_4h.weight",
+            "mlp.dense_4h_to_h.bias",
+            "mlp.dense_4h_to_h.weight",
+        ]
+
+        state_dict = model.state_dict()
+        model_named_parameters = dict()
+        for name, param in state_dict.items():
+            if "embed" in name:
+                model_named_parameters[name] = param
+            elif "output_layer" in name:
+                model_named_parameters[name] = param
+            else:
+                model_named_parameters[name] = param.permute(1, 0) if len(param.shape) == 2 else param
+
+        pool = multiprocessing.Pool(processes)
+        for name, param in model_named_parameters.items():
+            if name == "transformer.embedding.word_embeddings.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(os.path.join(output_dir, "model.wte.bin"))
+            elif name == "transformer.encoder.final_layernorm.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.final_layernorm.weight.bin")
+                )
+            elif name == "transformer.output_layer.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.lm_head.weight.bin")
+                )
+            else:
+                starmap_args = []
+                for i in range(len(huggingface_model_name_pattern)):
+                    if huggingface_model_name_pattern[i] in name:
+                        factor = 1
+                        new_name = name.replace("transformer.encoder.layers.", "layers.").replace(
+                            huggingface_model_name_pattern[i], ft_model_name_pattern[i]
+                        )
+                        starmap_args.append(
+                            (
+                                0,
+                                output_dir,
+                                factor,
+                                new_name,
+                                param.detach().cpu().numpy().astype(self.dtype),
+                                num_attention_heads,
+                                multi_query_group_num,
+                                kv_channels,
+                            )
+                        )
+                pool.starmap_async(self.split_and_convert_process, starmap_args)
+        pool.close()
+        pool.join()

--- a/src/xfastertransformer/tools/chatglm_convert.py
+++ b/src/xfastertransformer/tools/chatglm_convert.py
@@ -1,0 +1,215 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+import configparser
+import multiprocessing
+import numpy as np
+import os
+
+from transformers import AutoModel
+
+from .convert import BaseModelConvert
+
+
+class ChatGLMConvert(BaseModelConvert):
+    """
+    Convert huggingface ChatGLM model. Use https://huggingface.co/THUDM/chatglm-6b
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def split_and_convert_process(self, i, saved_dir, factor, key, val):
+        def save_val(val, key, tp_num=None):
+            path = os.path.join(saved_dir, "model." + key)
+            if tp_num is not None:
+                path += "." + str(tp_num)
+            path += ".bin"
+
+            val.tofile(path)
+
+        if (
+            "input_layernorm.weight" in key
+            or "input_layernorm.bias" in key
+            or "attention.dense.bias" in key
+            or "post_attention_layernorm.weight" in key
+            or "post_attention_layernorm.bias" in key
+            or "mlp.dense_4h_to_h.bias" in key
+            or "final_layernorm.weight" in key
+            or "final_layernorm.bias" in key
+        ):
+            # shared weights, only need to convert the weights of rank 0
+            if i == 0:
+                save_val(val, key)
+
+        elif "attention.dense.weight" in key or "mlp.dense_4h_to_h.weight" in key:
+            split_vals = np.split(val, factor, axis=0)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "mlp.dense_h_to_4h.weight" in key or "mlp.dense_h_to_4h.bias" in key:
+            split_vals = np.split(val, factor, axis=-1)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "attention.query_key_value.bias" in key:
+            hidden_dim = (int)(val.shape[-1] / 3)
+
+            # TODO: hard coded num_attention_heads as 32, size per head as 128
+            val = val.reshape(32, 128 * 3)
+            qkv = np.split(val, 3, axis=-1)
+            q = qkv[0].reshape(1, hidden_dim)
+            k = qkv[1].reshape(1, hidden_dim)
+            v = qkv[2].reshape(1, hidden_dim)
+            val = np.concatenate((q, k, v), axis=-1)
+
+            split_vals = np.split(val, factor, axis=-1)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "attention.query_key_value.weight" in key:
+            hidden_dim = val.shape[0]
+
+            # TODO: hard coded num_attention_heads as 32, size per head as 128
+            val = val.reshape(hidden_dim, 32, 128 * 3)
+            qkv = np.split(val, 3, axis=-1)
+            q = qkv[0].reshape(hidden_dim, hidden_dim)
+            k = qkv[1].reshape(hidden_dim, hidden_dim)
+            v = qkv[2].reshape(hidden_dim, hidden_dim)
+            val = np.concatenate((q, k, v), axis=-1)
+
+            split_vals = np.split(val, factor, axis=-1)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        else:
+            print("[ERROR] cannot find key '{}'".format(key))
+
+    def split_and_convert(self, input_dir, output_dir, dtype, processes):
+        # create directory if not exist
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        # load the model
+        model = AutoModel.from_pretrained(input_dir, trust_remote_code=True)
+
+        hf_config = vars(model.config)
+
+        layer_names = [name for name, param in model.named_parameters()]
+
+        # save parameters to config file
+        config = configparser.ConfigParser()
+        config["chatglm"] = {}
+        has_post_decoder_layernorm = "model.decoder.final_layer_norm.bias" in layer_names
+        try:
+            config["chatglm"]["model_name"] = (
+                "chatglm" if hf_config["_name_or_path"] == "" else hf_config["_name_or_path"]
+            )
+            config["chatglm"]["head_num"] = str(hf_config["num_attention_heads"])
+            n_embd = hf_config["hidden_size"]
+            config["chatglm"]["size_per_head"] = str(n_embd // hf_config["num_attention_heads"])
+            config["chatglm"]["inter_size"] = str(hf_config["inner_hidden_size"])
+            config["chatglm"]["max_pos_seq_len"] = str(hf_config["max_sequence_length"])
+            config["chatglm"]["num_layer"] = str(hf_config["num_layers"])
+            config["chatglm"]["layernorm_eps"] = "1e-5"
+            config["chatglm"]["layernorm_type"] = "pre_layernorm"
+            config["chatglm"]["activation_type"] = "Gelu"
+            config["chatglm"]["has_post_decoder_layernorm"] = "1" if has_post_decoder_layernorm else "0"
+            config["chatglm"]["vocab_size"] = str(hf_config["vocab_size"])
+            config["chatglm"]["start_id"] = str(hf_config["bos_token_id"])
+            config["chatglm"]["end_id"] = str(hf_config["eos_token_id"])
+            config["chatglm"]["weight_data_type"] = dtype
+            with open(os.path.join(output_dir, "config.ini"), "w") as configfile:
+                config.write(configfile)
+        except Exception as e:
+            print("Fail to save the config in config.ini.", str(e))
+
+        huggingface_model_name_pattern = [
+            "input_layernorm.bias",
+            "input_layernorm.weight",
+            "attention.query_key_value.bias",
+            "attention.query_key_value.weight",
+            "attention.dense.bias",
+            "attention.dense.weight",
+            "post_attention_layernorm.bias",
+            "post_attention_layernorm.weight",
+            "mlp.dense_h_to_4h.bias",
+            "mlp.dense_h_to_4h.weight",
+            "mlp.dense_4h_to_h.bias",
+            "mlp.dense_4h_to_h.weight",
+        ]
+
+        ft_model_name_pattern = [
+            "input_layernorm.bias",
+            "input_layernorm.weight",
+            "attention.query_key_value.bias",
+            "attention.query_key_value.weight",
+            "attention.dense.bias",
+            "attention.dense.weight",
+            "post_attention_layernorm.bias",
+            "post_attention_layernorm.weight",
+            "mlp.dense_h_to_4h.bias",
+            "mlp.dense_h_to_4h.weight",
+            "mlp.dense_4h_to_h.bias",
+            "mlp.dense_4h_to_h.weight",
+        ]
+
+        state_dict = model.state_dict()
+        model_named_parameters = dict()
+        for name, param in state_dict.items():
+            print(name)
+            if "embed" in name:
+                model_named_parameters[name] = param
+            elif "lm_head" in name:
+                model_named_parameters[name] = param
+            else:
+                model_named_parameters[name] = param.permute(1, 0) if len(param.shape) == 2 else param
+
+        pool = multiprocessing.Pool(processes)
+        for name, param in model_named_parameters.items():
+            if name == "transformer.word_embeddings.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(os.path.join(output_dir, "model.wte.bin"))
+            elif name == "transformer.final_layernorm.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.final_layernorm.weight.bin")
+                )
+            elif name == "transformer.final_layernorm.bias":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.final_layernorm.bias.bin")
+                )
+            elif name == "lm_head.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.lm_head.weight.bin")
+                )
+            else:
+                starmap_args = []
+                for i in range(len(huggingface_model_name_pattern)):
+                    if huggingface_model_name_pattern[i] in name:
+                        factor = 1
+                        new_name = name.replace("transformer.layers.", "layers.").replace(
+                            huggingface_model_name_pattern[i], ft_model_name_pattern[i]
+                        )
+                        starmap_args.append(
+                            (
+                                0,
+                                output_dir,
+                                factor,
+                                new_name,
+                                param.detach().cpu().numpy().astype(self.dtype),
+                            )
+                        )
+                pool.starmap_async(self.split_and_convert_process, starmap_args)
+        pool.close()
+        pool.join()

--- a/src/xfastertransformer/tools/convert.py
+++ b/src/xfastertransformer/tools/convert.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import numpy as np
+import os
+
+
+class BaseModelConvert:
+    def __init__(self):
+        self.dtype = np.float32
+
+    def __call__(self, input_dir, output_dir=None, dtype: str = "fp16", processes=8):
+        self.convert(input_dir, output_dir, dtype, processes)
+
+    def get_weight_data_type(self, dtype: str):
+        if dtype == "fp32":
+            return np.float32
+        elif dtype == "fp16":
+            return np.float16
+        else:
+            raise Exception(f"{self.__class__.__name__} don't support convert weight to {dtype}.")
+
+    def convert(self, input_dir, output_dir=None, dtype: str = "fp16", processes=8):
+        self.dtype = self.get_weight_data_type(dtype)
+        if output_dir is None:
+            input_dir = input_dir.rstrip(os.path.sep)
+            output_dir = os.path.join(os.path.dirname(input_dir), os.path.basename(input_dir) + "-xft")
+
+        self.split_and_convert(input_dir, output_dir, dtype, processes)
+
+    def split_and_convert(self, input_dir, output_dir, dtype, processes):
+        pass

--- a/src/xfastertransformer/tools/llama_convert.py
+++ b/src/xfastertransformer/tools/llama_convert.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+
+import configparser
+import multiprocessing
+import numpy as np
+import os
+import torch
+
+from transformers import LlamaForCausalLM
+
+from .convert import BaseModelConvert
+
+
+class LlamaConvert(BaseModelConvert):
+    """
+    Convert huggingface Llama model. Support both Llama & Llama2.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def split_and_convert_process(self, i, output_dir, factor, key, val, num_attention_heads, num_key_value_heads):
+        def save_val(val, key, tp_num=None):
+            if key.startswith("model."):
+                path = os.path.join(output_dir, key)
+            else:
+                path = os.path.join(output_dir, "model." + key)
+
+            if tp_num is not None:
+                path += "." + str(tp_num)
+            path += ".bin"
+
+            val.tofile(path)
+
+        if (
+            "input_layernorm.weight" in key
+            or "input_layernorm.bias" in key
+            or "attention.dense.bias" in key
+            or "post_attention_layernorm.weight" in key
+            or "post_attention_layernorm.bias" in key
+            or "mlp.dense_4h_to_h.bias" in key
+            or "final_layernorm.weight" in key
+            or "final_layernorm.bias" in key
+        ):
+            # shared weights, only need to convert the weights of rank 0
+            if i == 0:
+                save_val(val, key)
+
+        elif "mlp.gate_proj.weight" in key or "mlp.up_proj.weight" in key or "mlp.down_proj.weight" in key:
+            split_vals = np.split(val, factor, axis=0)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "attention.query_key_value.weight" in key:
+            qkvcols = val.shape[-1]
+            head_size = int(qkvcols / (int(num_attention_heads) + int(num_key_value_heads) * 2))
+            qcol = int(num_attention_heads) * head_size
+            kcol = int(num_key_value_heads) * head_size
+            vcol = int(num_key_value_heads) * head_size
+            qkv = np.split(val, [qcol, (qcol + kcol)], axis=-1)
+            q = qkv[0]
+            k = qkv[1]
+            v = qkv[2]
+            q_split_vals = np.split(q, factor, axis=-1)
+            k_split_vals = np.split(k, factor, axis=-1)
+            v_split_vals = np.split(v, factor, axis=-1)
+            for j in range(factor):
+                val = np.concatenate((q_split_vals[j], k_split_vals[j], v_split_vals[j]), axis=-1)
+                save_val(val, key, i * factor + j)
+
+        elif "attention.dense.weight" in key:
+            split_vals = np.split(val, factor, axis=0)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        else:
+            print("[ERROR] cannot find key '{}'".format(key))
+
+    def split_and_convert(self, input_dir, output_dir, dtype, processes):
+        # create directory if not exist
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        # load the model
+        model = LlamaForCausalLM.from_pretrained(
+            input_dir,
+            load_in_8bit=False,
+            torch_dtype=torch.float16,
+            low_cpu_mem_usage=True,
+            device_map="auto",
+        )
+
+        hf_config = vars(model.config)
+
+        # save parameters to config file
+        config = configparser.ConfigParser()
+        config["llama"] = {}
+        has_post_decoder_layernorm = True
+        try:
+            config["llama"]["model_name"] = "llama" if hf_config["_name_or_path"] == "" else hf_config["_name_or_path"]
+            num_attention_heads = config["llama"]["head_num"] = str(hf_config["num_attention_heads"])
+            num_key_value_heads = config["llama"]["kv_head_num"] = str(
+                hf_config.get("num_key_value_heads", num_attention_heads)
+            )
+
+            hidden_size = hf_config["hidden_size"]
+            config["llama"]["size_per_head"] = str(hidden_size // hf_config["num_attention_heads"])
+            config["llama"]["inter_size"] = str(hf_config["intermediate_size"])
+            config["llama"]["max_pos_seq_len"] = str(hf_config["max_position_embeddings"])
+            config["llama"]["num_layer"] = str(hf_config["num_hidden_layers"])
+            config["llama"]["rms_norm_eps"] = "1e-6"
+            config["llama"]["layernorm_type"] = "pre_layernorm"
+            config["llama"]["activation_type"] = "silu"
+            config["llama"]["has_post_decoder_layernorm"] = "1" if has_post_decoder_layernorm else "0"
+            config["llama"]["vocab_size"] = str(hf_config["vocab_size"])
+            config["llama"]["start_id"] = str(hf_config["bos_token_id"])
+            config["llama"]["end_id"] = str(hf_config["eos_token_id"])
+            config["llama"]["weight_data_type"] = dtype
+            with open(os.path.join(output_dir, "config.ini"), "w") as configfile:
+                config.write(configfile)
+        except Exception as e:
+            print("Fail to save the config in config.ini.", str(e))
+
+        hf_model_name_pattern = [
+            "input_layernorm.weight",
+            "attention.query_key_value.weight",
+            "self_attn.o_proj.weight",
+            "post_attention_layernorm.weight",
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+            "mlp.down_proj.weight",
+        ]
+
+        ft_model_name_pattern = [
+            "input_layernorm.weight",
+            "attention.query_key_value.weight",
+            "attention.dense.weight",
+            "post_attention_layernorm.weight",
+            "mlp.gate_proj.weight",
+            "mlp.up_proj.weight",
+            "mlp.down_proj.weight",
+        ]
+
+        state_dict = model.state_dict()
+        model_named_parameters = dict()
+        for name, param in state_dict.items():
+            print(name)
+            # merge QKV
+            if "self_attn.q_proj.weight" in name:
+                k_name = name.replace("q_proj", "k_proj")
+                v_name = name.replace("q_proj", "v_proj")
+                qkv = torch.cat(
+                    (param.permute(1, 0), state_dict[k_name].permute(1, 0), state_dict[v_name].permute(1, 0)), dim=1
+                )
+                model_named_parameters[
+                    name.replace("self_attn.q_proj.weight", "attention.query_key_value.weight")
+                ] = qkv
+            # for merged weights, skip
+            elif "self_attn.k_proj.weight" in name or "self_attn.v_proj.weight" in name:
+                continue
+            elif "embed" in name:
+                model_named_parameters[name] = param
+            elif "lm_head" in name:
+                model_named_parameters[name] = param
+            else:
+                model_named_parameters[name] = param.permute(1, 0) if len(param.shape) == 2 else param
+
+        pool = multiprocessing.Pool(processes)
+        for name, param in model_named_parameters.items():
+            if name == "model.embed_tokens.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(os.path.join(output_dir, "model.wte.bin"))
+            elif name == "model.norm.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.final_layernorm.weight.bin")
+                )
+            elif name == "lm_head.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.lm_head.weight.bin")
+                )
+            else:
+                starmap_args = []
+                for i in range(len(hf_model_name_pattern)):
+                    if hf_model_name_pattern[i] in name:
+                        factor = 1
+                        new_name = name.replace(hf_model_name_pattern[i], ft_model_name_pattern[i])
+                        starmap_args.append(
+                            (
+                                0,
+                                output_dir,
+                                factor,
+                                new_name,
+                                param.detach().cpu().numpy().astype(self.dtype),
+                                num_attention_heads,
+                                num_key_value_heads,
+                            )
+                        )
+                pool.starmap_async(self.split_and_convert_process, starmap_args)
+        pool.close()
+        pool.join()

--- a/src/xfastertransformer/tools/opt_convert.py
+++ b/src/xfastertransformer/tools/opt_convert.py
@@ -1,0 +1,248 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import configparser
+import multiprocessing
+import numpy as np
+import os
+import torch
+
+from transformers import AutoModelForCausalLM
+
+
+from .convert import BaseModelConvert
+
+
+class OPTConvert(BaseModelConvert):
+    """
+    Convert huggingface Meta OPT model. Use https://huggingface.co/facebook/opt-13b as demo.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+    def split_and_convert_process(self, i, saved_dir, factor, key, val):
+        def save_val(val, key, tp_num=None):
+            path = os.path.join(saved_dir, "model." + key)
+            if tp_num is not None:
+                path += "." + str(tp_num)
+            path += ".bin"
+
+            val.tofile(path)
+
+        if (
+            "input_layernorm.weight" in key
+            or "input_layernorm.bias" in key
+            or "attention.dense.bias" in key
+            or "post_attention_layernorm.weight" in key
+            or "post_attention_layernorm.bias" in key
+            or "mlp.dense_4h_to_h.bias" in key
+            or "final_layernorm.weight" in key
+            or "final_layernorm.bias" in key
+        ):
+            # shared weights, only need to convert the weights of rank 0
+            if i == 0:
+                save_val(val, key)
+
+        elif "attention.dense.weight" in key or "mlp.dense_4h_to_h.weight" in key:
+            split_vals = np.split(val, factor, axis=0)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "mlp.dense_h_to_4h.weight" in key or "mlp.dense_h_to_4h.bias" in key:
+            split_vals = np.split(val, factor, axis=-1)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "attention.query_key_value.bias" in key:
+            local_dim = (int)(val.shape[-1] / 3)
+
+            val = val.reshape(3, local_dim)
+            split_vals = np.split(val, factor, axis=-1)
+
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        elif "attention.query_key_value.weight" in key:
+            hidden_dim = val.shape[0]
+            local_dim = (int)(val.shape[-1] / 3)
+
+            val = val.reshape(hidden_dim, 3, local_dim)
+
+            split_vals = np.split(val, factor, axis=-1)
+            for j in range(factor):
+                save_val(split_vals[j], key, i * factor + j)
+
+        else:
+            print("[ERROR] cannot find key '{}'".format(key))
+
+    def split_and_convert(self, input_dir, output_dir, dtype, processes):
+        def fuse_qkv_weight(q, k, v):
+            if isinstance(q, float):
+                qkv = torch.tensor((q, k, v))
+            else:
+                qkv = torch.cat([q, k, v], dim=-1)
+            return qkv
+
+        if os.path.exists(output_dir) == False:
+            os.makedirs(output_dir)
+
+        factor = 1
+
+        # load position_embedding from rank 0
+        model = AutoModelForCausalLM.from_pretrained(input_dir, device_map="auto")
+
+        hf_config = vars(model.config)
+
+        num_layers = hf_config["num_hidden_layers"]
+
+        layer_names = [name for name, param in model.named_parameters()]
+
+        # NOTE: save parameters to config files (loaded by triton backends)
+        config = configparser.ConfigParser()
+        config["gpt"] = {}
+        has_post_decoder_layernorm = "model.decoder.final_layer_norm.bias" in layer_names
+        try:
+            config["gpt"]["model_name"] = "opt" if hf_config["_name_or_path"] == "" else hf_config["_name_or_path"]
+            config["gpt"]["head_num"] = str(hf_config["num_attention_heads"])
+            n_embd = hf_config["hidden_size"]
+            config["gpt"]["size_per_head"] = str(n_embd // hf_config["num_attention_heads"])
+            config["gpt"]["inter_size"] = str(hf_config["ffn_dim"])
+            config["gpt"]["max_pos_seq_len"] = str(hf_config["max_position_embeddings"])
+            config["gpt"]["num_layer"] = str(hf_config["num_hidden_layers"])
+            config["gpt"]["layernorm_eps"] = "1e-5"
+            config["gpt"]["layernorm_type"] = "pre_layernorm" if hf_config["do_layer_norm_before"] else "post_layernorm"
+            config["gpt"]["activation_type"] = "Relu"
+            config["gpt"]["has_post_decoder_layernorm"] = "1" if has_post_decoder_layernorm else "0"
+            config["gpt"]["vocab_size"] = str(hf_config["vocab_size"])
+            config["gpt"]["start_id"] = str(hf_config["bos_token_id"])
+            config["gpt"]["end_id"] = str(hf_config["eos_token_id"])
+            config["gpt"]["weight_data_type"] = dtype
+            # config['gpt']['int8'] = str(save_int8) # really useful?
+            with open(os.path.join(output_dir, "config.ini"), "w") as configfile:
+                config.write(configfile)
+        except:
+            print(f"Fail to save the config in config.ini.")
+
+        huggingface_model_name_pattern = [
+            "self_attn_layer_norm.bias",
+            "self_attn_layer_norm.weight",
+            "self_attn.qkv_proj.bias",
+            "self_attn.qkv_proj.weight",
+            "self_attn.out_proj.bias",
+            "self_attn.out_proj.weight",
+            "final_layer_norm.bias",
+            "final_layer_norm.weight",
+            "fc1.bias",
+            "fc1.weight",
+            "fc2.bias",
+            "fc2.weight",
+        ]
+
+        ft_model_name_pattern = [
+            "input_layernorm.bias",
+            "input_layernorm.weight",
+            "attention.query_key_value.bias",
+            "attention.query_key_value.weight",
+            "attention.dense.bias",
+            "attention.dense.weight",
+            "post_attention_layernorm.bias",
+            "post_attention_layernorm.weight",
+            "mlp.dense_h_to_4h.bias",
+            "mlp.dense_h_to_4h.weight",
+            "mlp.dense_4h_to_h.bias",
+            "mlp.dense_4h_to_h.weight",
+        ]
+
+        model_named_parameters_iter = model.named_parameters()
+        model_named_parameters = dict()
+        for name, param in model_named_parameters_iter:
+            if "embed" in name:
+                model_named_parameters[name] = param
+            elif "project_in" in name:
+                model_named_parameters[name] = param.permute(1, 0)
+            elif "project_out" in name:
+                model_named_parameters[name] = param
+            else:
+                model_named_parameters[name] = param.permute(1, 0) if len(param.shape) == 2 else param
+
+        for l in range(num_layers):
+            prefix = f"model.decoder.layers.{l}.self_attn."
+            q_weight = model_named_parameters[prefix + "q_proj.weight"]
+            k_weight = model_named_parameters[prefix + "k_proj.weight"]
+            v_weight = model_named_parameters[prefix + "v_proj.weight"]
+            q_bias = model_named_parameters[prefix + "q_proj.bias"]
+            k_bias = model_named_parameters[prefix + "k_proj.bias"]
+            v_bias = model_named_parameters[prefix + "v_proj.bias"]
+            qkv_weight = fuse_qkv_weight(q_weight, k_weight, v_weight)
+            qkv_bias = fuse_qkv_weight(q_bias, k_bias, v_bias)
+
+            model_named_parameters[prefix + "qkv_proj.weight"] = qkv_weight
+            model_named_parameters[prefix + "qkv_proj.bias"] = qkv_bias
+
+        pool = multiprocessing.Pool(processes)
+        padding_offset = 2
+        for name, param in model_named_parameters.items():
+            if name == "model.decoder.embed_positions.weight":
+                param[padding_offset:, ...].detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.wpe.bin")
+                )
+
+            elif name == "model.decoder.embed_tokens.weight":
+                if "model.decoder.project_in.weight" in model_named_parameters.keys():
+                    project_in = model_named_parameters["model.decoder.project_in.weight"]
+                    project_out = model_named_parameters["model.decoder.project_out.weight"]
+                    torch.matmul(param, project_in).detach().cpu().numpy().astype(self.dtype).tofile(
+                        os.path.join(output_dir, "model.wte.bin")
+                    )
+                    torch.matmul(param, project_out).detach().cpu().numpy().astype(self.dtype).tofile(
+                        os.path.join(output_dir, "model.lm_head.weight.bin")
+                    )
+
+                else:
+                    param.detach().cpu().numpy().astype(self.dtype).tofile(os.path.join(output_dir, "model.wte.bin"))
+                    param.detach().cpu().numpy().astype(self.dtype).tofile(
+                        os.path.join(output_dir, "model.lm_head.weight.bin")
+                    )
+
+            elif name == "model.decoder.final_layer_norm.weight":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.final_layernorm.weight.bin")
+                )
+            elif name == "model.decoder.final_layer_norm.bias":
+                param.detach().cpu().numpy().astype(self.dtype).tofile(
+                    os.path.join(output_dir, "model.final_layernorm.bias.bin")
+                )
+            elif "project_in" in name or "project_out" in name:
+                continue
+            else:
+                starmap_args = []
+                for i in range(len(huggingface_model_name_pattern)):
+                    if huggingface_model_name_pattern[i] in name:
+                        new_name = name.replace("model.decoder.layers.", "layers.").replace(
+                            huggingface_model_name_pattern[i], ft_model_name_pattern[i]
+                        )
+
+                        starmap_args.append(
+                            (
+                                0,
+                                output_dir,
+                                factor,
+                                new_name,
+                                param.detach().cpu().numpy().astype(self.dtype),
+                            )
+                        )
+                pool.starmap_async(self.split_and_convert_process, starmap_args)
+        pool.close()
+        pool.join()


### PR DESCRIPTION
Usage：
```
import xfastertransformer as xft
converter = xft.LlamaConvert()
converter("/data/llama-2-7b-chat","/data/llama-2-7b-chat-xft", "fp16")
```
Params:`input_dir, output_dir=None, dtype: str = "fp16", processes=8`
if `output_dir` is `None`, default use `input_dir` with a suffix `-xft`, like:
```
converter("/data/llama-2-7b-chat")
# use output_dir = "/data/llama-2-7b-chat-xft"
```
Support converter list:
```
LlamaConvert
ChatGLMConvert
ChatGLM2Convert
OPTConvert
BaichuanConvert
```

TODO:
- README
- Lazy import
- hugging face dependency version