### PR TITLE
[issue] Raise an obvious exception if max_pos_seq_len is small

### DIFF
--- a/src/models/common_decoder.h
+++ b/src/models/common_decoder.h
@@ -149,6 +149,11 @@ public:
         this->embeddingForward(ids, this->embBuf->Data(), batchSize, seqLen);
         this->accSeqLen += seqLen;
 
+        if (this->accSeqLen > ctx->maxPositions){
+            throw std::invalid_argument(
+                "The token number attempting to generate exceeds 'config.ini: max_pos_seq_len'");
+        }
+
         // Prepare attention mask
         this->prepareAttnMask(ids, step);
 


### PR DESCRIPTION
For issue #87.

If the sum of input and output token lengths exceeds max_pos_seq_len, setting in config.ini, raise an exception and indicating the reason.