### PR TITLE
[Dockerfile] Fix _b2 module missing.

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zlib1g-dev \
     libssl-dev \
     libffi-dev \
+    libbz2-dev \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 60 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 60 \
     && rm -rf /var/lib/apt/lists/*

--- a/dockerfiles/Dockerfile.release
+++ b/dockerfiles/Dockerfile.release
@@ -31,6 +31,7 @@ RUN apt-get update \
     zlib1g-dev \
     libssl-dev \
     libffi-dev \
+    libbz2-dev \
     && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 60 \
     && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 60 \
     && apt-get autoremove -y \
@@ -113,4 +114,5 @@ RUN rm -rf /root/xFasterTransformer \
     dbus \
     libdbus-1-3 \
     libapparmor1 \
-    libldap-2.5-0
+    libldap-2.5-0 \
+    libbz2-dev


### PR DESCRIPTION
![image](https://github.com/intel/xFasterTransformer/assets/83744562/9127a417-aa58-4534-949e-a55b8315b9f0)
Fix _b2 module missing when run llama web demo in docker image.