### PR TITLE
clang-format: Remove duplicated IndentPPDirectives entry

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -58,7 +58,6 @@ IncludeCategories:
     Priority: 0
 IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: true
-IndentPPDirectives: AfterHash
 IndentPPDirectives: None
 IndentWidth:     4
 IndentWrappedFunctionNames: false


### PR DESCRIPTION
Prefer "IndentPPDirectives=None" with following layout:

#if FOO
#if BAR
#include <foo>
#endif
#endif