### PR TITLE
[Framework] Attention/LayerNorm/RmsNorm refactor/enhance to better support BF16 inference.

### DIFF
--- a/src/common/bfloat16.h
+++ b/src/common/bfloat16.h
@@ -98,7 +98,7 @@ inline void bfloat16_t::cvt_float_to_bfloat16(const float *src, bfloat16_t *dst,
     const __m512i ones = _mm512_set1_epi32(0x1);
     const __m512i vec_bias = _mm512_set1_epi32(0x7fff);
 
-#if (__GNUC__ > 12) || ((__GNUC__ == 12) && (__GNUC_MINOR__ >= 3))
+#if (__GNUC__ > 10) || ((__GNUC__ == 10) && (__GNUC_MINOR__ >= 1))
     auto cvt_fp32_to_bf16 = [&](const __m512 input_vector) { return (__m256i)_mm512_cvtneps_pbh(input_vector); };
 #else
     auto cvt_fp32_to_bf16 = [&](const __m512 input_vector) {

--- a/src/kernels/rmsnorm_kernels.cpp
+++ b/src/kernels/rmsnorm_kernels.cpp
@@ -23,17 +23,38 @@
 
 namespace xft {
 
-void invokeRmsNorm(float *output, const float *input, const float *weight, int rows, int cols, int iStride, int oStride,
+template <typename T>
+void rmsNorm(T *output, const float *input, const float *weight, int rows, int cols, int iStride, int oStride,
         float epsilon) {
-    int size = cols;
+    static_assert(std::is_same_v<T, float> || std::is_same_v<T, bfloat16_t>,
+            "Template parameter of rmsNorm must be either float or bfloat16_t");
 
+#if (__GNUC__ > 10) || ((__GNUC__ == 10) && (__GNUC_MINOR__ >= 1))
+    auto cvt_fp32_to_bf16 = [&](const __m512 input_vector) { return (__m256i)_mm512_cvtneps_pbh(input_vector); };
+#else
+    const __m512i nan = _mm512_set1_epi32(0xffff);
+    const __m512i ones = _mm512_set1_epi32(0x1);
+    const __m512i vec_bias = _mm512_set1_epi32(0x7fff);
+    auto cvt_fp32_to_bf16 = [&](const __m512 input_vector) {
+        __m512i value = _mm512_castps_si512(input_vector);
+        auto mask = _mm512_cmp_ps_mask(input_vector, input_vector, _CMP_ORD_Q);
+        auto result = _mm512_and_si512(_mm512_srli_epi32(value, 16), ones);
+        result = _mm512_add_epi32(result, vec_bias);
+        result = _mm512_add_epi32(result, value);
+        result = _mm512_srli_epi32(result, 16);
+        result = _mm512_mask_blend_epi32(mask, nan, result);
+        return _mm512_cvtusepi32_epi16(result);
+    };
+#endif
+
+    int size = cols;
     if (iStride == -1) iStride = cols;
     if (oStride == -1) oStride = cols;
 
 #pragma omp parallel for
     for (int r = 0; r < rows; ++r) {
         const float *px = input + r * iStride;
-        float *py = output + r * oStride;
+        T *py = output + r * oStride;
 
         float squareSum = 0;
 
@@ -63,20 +84,32 @@ void invokeRmsNorm(float *output, const float *input, const float *weight, int r
             __m512 vx = _mm512_loadu_ps(px + col);
             __m512 vw = _mm512_loadu_ps(weight + col);
             __m512 vy = vx * vvar * vw;
-            _mm512_storeu_ps(py + col, vy);
+            if constexpr (std::is_same_v<T, float>) {
+                _mm512_storeu_ps(py + col, vy);
+            }
+            if constexpr (std::is_same_v<T, bfloat16_t>) {
+                __m256i vbf16 = cvt_fp32_to_bf16(vy);
+                _mm256_mask_storeu_epi16(py + col, 0xffff, vbf16);
+            }
         }
         if (col < size) {
             __mmask16 mask = (1 << (size - col)) - 1;
             __m512 vx = _mm512_maskz_loadu_ps(mask, px + col);
             __m512 vw = _mm512_maskz_loadu_ps(mask, weight + col);
             __m512 vy = vx * vvar * vw;
-            _mm512_mask_storeu_ps(py + col, mask, vy);
+            if constexpr (std::is_same_v<T, float>) {
+                _mm512_mask_storeu_ps(py + col, mask, vy);
+            }
+            if constexpr (std::is_same_v<T, bfloat16_t>) {
+                __m256i vbf16 = cvt_fp32_to_bf16(vy);
+                _mm256_mask_storeu_epi16(py + col, mask, vbf16);
+            }
         }
     } // end for rows
 }
 
-void invokeRmsNorm(bfloat16_t *output, const bfloat16_t *input, const bfloat16_t *weight, int rows, int cols,
-        int iStride, int oStride, float epsilon) {
+void rmsNorm(bfloat16_t *output, const bfloat16_t *input, const bfloat16_t *weight, int rows, int cols, int iStride,
+        int oStride, float epsilon) {
     int size = cols;
 
     if (iStride == -1) iStride = cols;
@@ -127,13 +160,22 @@ void invokeRmsNorm(bfloat16_t *output, const bfloat16_t *input, const bfloat16_t
     } // end for rows
 }
 
+void rmsNorm(float *output, const float *input, const float *weight, int rows, int cols, int iStride, int oStride,
+        float epsilon) {
+    rmsNorm<float>(output, input, weight, rows, cols, iStride, oStride, epsilon);
+}
+
+void rmsNorm(bfloat16_t *output, const float *input, const float *weight, int rows, int cols, int iStride, int oStride,
+        float epsilon) {
+    rmsNorm<bfloat16_t>(output, input, weight, rows, cols, iStride, oStride, epsilon);
+}
+
 void invokeRmsNorm(DataType dt, void *output, const void *input, const void *weight, int rows, int cols, int iStride,
         int oStride, float epsilon) {
     if (dt == DataType::fp32) {
-        invokeRmsNorm((float *)output, (const float *)input, (const float *)weight, rows, cols, iStride,
-                oStride, epsilon);
+        rmsNorm((float *)output, (const float *)input, (const float *)weight, rows, cols, iStride, oStride, epsilon);
     } else if (dt == DataType::bf16) {
-        invokeRmsNorm((bfloat16_t *)output, (const bfloat16_t *)input, (const bfloat16_t *)weight, rows, cols, iStride,
+        rmsNorm((bfloat16_t *)output, (const bfloat16_t *)input, (const bfloat16_t *)weight, rows, cols, iStride,
                 oStride, epsilon);
     }
 }

--- a/src/kernels/rmsnorm_kernels.h
+++ b/src/kernels/rmsnorm_kernels.h
@@ -22,10 +22,13 @@
 
 namespace xft {
 
-void invokeRmsNorm(float *output, const float *input, const float *weight, int rows, int cols, int iStride = -1,
+void rmsNorm(float *output, const float *input, const float *weight, int rows, int cols, int iStride = -1,
         int oStride = -1, float epsilon = 1e-6);
 
-void invokeRmsNorm(bfloat16_t *output, const bfloat16_t *input, const bfloat16_t *weight, int rows, int cols,
+void rmsNorm(bfloat16_t *output, const float *input, const float *weight, int rows, int cols, int iStride = -1,
+        int oStride = -1, float epsilon = 1e-6);
+
+void rmsNorm(bfloat16_t *output, const bfloat16_t *input, const bfloat16_t *weight, int rows, int cols,
         int iStride = -1, int oStride = -1, float epsilon = 1e-6);
 
 } // namespace xft

--- a/src/layers/attention.h
+++ b/src/layers/attention.h
@@ -17,6 +17,7 @@
 
 #include "aligned_type.h"
 #include "bfloat16.h"
+#include "copy_util.h"
 #include "debugger.h"
 #include "decoder_util.h"
 #include "float16.h"
@@ -27,12 +28,18 @@
 #include "transformer_ctx.h"
 #include "transformer_util.h"
 
-// WeiT: weight data type
-// QKPO_CLS: class for post operation of query/key, it is generally the rotary embedding
-// NORM_CLS: class for layernorm or other norms
-// INPUT_AS_RESID: input as residential or not, most models use input as residential,
-//                 but there are exceptions like ChatGLM use values after layernorm as residential
-template <typename WeiT, typename QKPO_CLS, typename NORM_CLS, bool INPUT_AS_RESID = true>
+/**
+ * WeiT: weight data type
+ * InT: input data type
+ * ImT: intermediate data type
+ * OutT: output data type
+ * QKPO_CLS: class for post operation of query/key, it is generally the rotary embedding
+ * NORM_CLS: class for layernorm or other norms
+ * INPUT_AS_RESID: input as residential or not, most models use input as residential,
+ *                 but there are exceptions like ChatGLM use values after layernorm as residential
+*/
+template <typename WeiT, typename QKPO_CLS, typename NORM_CLS, typename InT = float, typename ImT = float,
+        typename OutT = float, bool INPUT_AS_RESID = true>
 class Attention {
 public:
     Attention(int layerId, DecoderContext *ctx) : layerId(layerId), qkpo(ctx->attHeadSize, ctx->maxPosEmbed) {
@@ -156,52 +163,40 @@ public:
      * Forward computing for the whole encoder/decoder layer
      * Inputs:
      * - input: (bs * seq_len) x hidden_size (input buffer)
-     * - imBuf: (bs * seq_len) x hidden_size (intermediate buffer, output is in ctx->tmpBuf)
+     * - imBuf: (bs * seq_len) x hidden_size (intermediate buffer)
+     * - output: (bs * seq_len) x hidden_size (output buffer)
      * - attnMask: (bs, 1, tgt_len, src_len) (tgt_len is the length of query, src_len is the length of key)
      * - presentKeys, presentValues: past key/values concats current key/values
      * - pastSeqLen: the sequence length in pastKeys and pastValues
      * - useSelfAttn: use self attention or not, self attention is used to gen first token
      * - doLnBefore: Do layer norm before or not. If true, will do layer norm as the first step
-     * - returnAttn: return attention values or not (this option is not used any more)
-     * - returnKVs: return present key/values or not (this option is not used any more)
-     * - forPT: is it for PyTorch or not (this option is not used any more), now cached keys/values are always controlled by us
-     * Internal Buffers:
+     *               currently only support doLnBefore=true
      *  _________                _________                _________                _________                _________                
-     * |         |------------->|         |------------->|         |------------->|         |------------->|         |
-     * ```````````  layerNorm   ```````````  QKV Linear  ```````````     MHA      ```````````  out Linear  ```````````
-     *    input                resultBuffer1              qkvMatMul               resultBuffer1            resultBuffer2
+     * |_________|------------->|_________|------------->|_________|------------->|_________|------------->|_________|
+     *              layerNorm                QKV Linear                  MHA                   out Linear             
+     *    input                   imBuffer                qkvMatMul                 imBuffer                  output
     */
     template <typename KVCacheT>
-    void forward(DecoderContext *ctx, float *input, float *imBuf, const float *attnMask,
+    void forward(DecoderContext *ctx, InT *input, ImT *imBuf, OutT *output, const float *attnMask,
             KVCacheTensor<KVCacheT> &presentKey, KVCacheTensor<KVCacheT> &presentValue, int inputSeqLen, int pastSeqLen,
-            bool useSelfAttn, bool doLnBefore, bool returnAttn, bool returnKVs, bool forPT = true,
-            int *positionIds = nullptr) {
-        if (forPT) {
-            printf("For better perf, need to manage cached key/vaues by ourself, PyTorch extension is not supported "
-                   "any more.\n");
-            exit(-1);
-        }
-
-        hpj::Matrix<float> inputBuffer(input, ctx->batchSize * inputSeqLen, ctx->hiddenSize, ctx->hiddenSize);
-        hpj::Matrix<float> imBuffer(imBuf, ctx->batchSize * inputSeqLen, ctx->hiddenSize, ctx->hiddenSize);
+            bool useSelfAttn, bool doLnBefore, int *positionIds = nullptr) {
 
         auto hiddenSize = ctx->hiddenSize;
-        auto &qkvMatMul = ctx->qkvMatMul;
-        auto &resultBuffer1 = imBuffer;
-        auto &resultBuffer2 = ctx->tmpBuf;
+        hpj::Matrix<InT> inputBuffer(input, ctx->batchSize * inputSeqLen, hiddenSize, hiddenSize);
+        hpj::Matrix<ImT> imBuffer(imBuf, ctx->batchSize * inputSeqLen, hiddenSize, hiddenSize);
+        hpj::Matrix<OutT> outBuffer(output, ctx->batchSize * inputSeqLen, hiddenSize, hiddenSize);
 
         float epsilon = ctx->epsilon;
-        // init group_qkvBuffer
-        int attHeadSize = ctx->attHeadSize;
+        int headSize = ctx->attHeadSize;
         int qkvRows = ctx->batchSize * inputSeqLen;
-        // group attention
-        int qCols = (this->endQHead - this->startQHead) * attHeadSize;
-        int kvCols = (this->endKVHead - this->startKVHead) * attHeadSize;
+        int qCols = (this->endQHead - this->startQHead) * headSize;
+        int kvCols = (this->endKVHead - this->startKVHead) * headSize;
         int qkCols = qCols + kvCols;
         int qkvCols = qkCols + kvCols;
 
         int qkvStride = qkvCols;
-        hpj::Matrix<float> qkvGroupMatMul(qkvMatMul.Data(), qkvRows, qkvCols, qkvStride);
+        auto &qkvMatMul = ctx->qkvMatMul;
+        hpj::Matrix<ImT> qkvGroupMatMul((ImT *)qkvMatMul.Data(), qkvRows, qkvCols, qkvStride);
 
 #ifdef DEBUG
         dbg.debugPrint("---- DecoderLayer.forward (useSelfAttn=%d) ----\n", useSelfAttn);
@@ -211,25 +206,24 @@ public:
 
         if (doLnBefore) {
             TimeLine t1("input.layer_norm");
-            norm.forward(inputBuffer.Data(), resultBuffer1.Data(), inputBuffer.Rows(), inputBuffer.Stride(),
-                    resultBuffer1.Stride(), epsilon);
+            norm.forward(inputBuffer.Data(), imBuffer.Data(), inputBuffer.Rows(), inputBuffer.Stride(),
+                    imBuffer.Stride(), epsilon);
         }
 #ifdef DEBUG
         dbg.debugPrint("layer norm:\n");
-        dbg.dumpMatrix(resultBuffer1);
+        dbg.dumpMatrix(imBuffer);
         dbg.debugPrint("qkvWeight [%d, %d]:\n", this->qkvWeight.Rows(), this->qkvWeight.Cols());
         dbg.dumpMatrix(this->qkvWeight);
 #endif
 
         // Query, Key, Value computed together
         TimeLine t2("QKV.linear");
-        DecoderUtil::dense(
-                resultBuffer1, qkvWeight, qkvWeightScale, qkvWeightZero, qkvWeightSum, qkvBias, qkvGroupMatMul);
+        DecoderUtil::dense(imBuffer, qkvWeight, qkvWeightScale, qkvWeightZero, qkvWeightSum, qkvBias, qkvGroupMatMul);
         t2.release();
 
-        hpj::Matrix<float> query(qkvGroupMatMul, 0, inputBuffer.Rows(), 0, qCols);
-        hpj::Matrix<float> key(qkvGroupMatMul, 0, inputBuffer.Rows(), qCols, kvCols);
-        hpj::Matrix<float> value(qkvGroupMatMul, 0, inputBuffer.Rows(), qkCols, kvCols);
+        hpj::Matrix<ImT> query(qkvGroupMatMul, 0, inputBuffer.Rows(), 0, qCols);
+        hpj::Matrix<ImT> key(qkvGroupMatMul, 0, inputBuffer.Rows(), qCols, kvCols);
+        hpj::Matrix<ImT> value(qkvGroupMatMul, 0, inputBuffer.Rows(), qkCols, kvCols);
 
 #ifdef DEBUG
         dbg.debugPrint("Q:\n");
@@ -240,22 +234,22 @@ public:
         dbg.dumpMatrix(value);
 #endif
 
-        // Apply post operattions on query and key
+        // Apply post operations on query and key
         TimeLine t3("QKPO");
         int qheads = this->endQHead - this->startQHead;
         int kheads = this->endKVHead - this->startKVHead;
-        int qk_shape[5] = {ctx->batchSize, ctx->inputSeqLen, qheads, ctx->attHeadSize, kheads};
+        int qkShape[5] = {ctx->batchSize, ctx->inputSeqLen, qheads, headSize, kheads};
         if (positionIds != nullptr) {
-            qkpo.forward(query.Data(), key.Data(), query.Stride(), key.Stride(), qk_shape, positionIds);
+            qkpo.forward(query.Data(), key.Data(), query.Stride(), key.Stride(), qkShape, positionIds);
         } else if (ctx->maxPosEmbed > 0) {
             // Use the default position ids
-            std::vector<int> position_ids(ctx->inputSeqLen);
+            std::vector<int> posIds(ctx->inputSeqLen);
             if (inputSeqLen == 1) {
-                position_ids[0] = pastSeqLen;
+                posIds[0] = pastSeqLen;
             } else {
-                std::iota(position_ids.begin(), position_ids.end(), pastSeqLen);
+                std::iota(posIds.begin(), posIds.end(), pastSeqLen);
             }
-            qkpo.forward(query.Data(), key.Data(), query.Stride(), key.Stride(), qk_shape, position_ids.data());
+            qkpo.forward(query.Data(), key.Data(), query.Stride(), key.Stride(), qkShape, posIds.data());
         }
         t3.release();
 
@@ -272,22 +266,21 @@ public:
         if (getScalingCoeff() != 0) { ctx->attFactor = getScalingCoeff(); }
 
         TimeLine t4("MHA");
-        if constexpr (!INPUT_AS_RESID) {
-            auto presult = resultBuffer1.Data();
-            int rows = resultBuffer1.Rows(), cols = resultBuffer1.Cols(), stride = resultBuffer1.Stride();
-            resultBuffer1.Assign(inputBuffer.Data(), inputBuffer.Rows(), inputBuffer.Cols(), inputBuffer.Stride());
-            inputBuffer.Assign(presult, rows, cols, stride);
+        if constexpr (!INPUT_AS_RESID) { // Swap inputBuffer and imBuffer
+            auto tmp = imBuffer.Data();
+            int rows = imBuffer.Rows(), cols = imBuffer.Cols(), stride = imBuffer.Stride();
+            imBuffer.Assign(inputBuffer.Data(), inputBuffer.Rows(), inputBuffer.Cols(), inputBuffer.Stride());
+            inputBuffer.Assign(tmp, rows, cols, stride);
         }
         // TODO: support large inputSeqLen when pastSeqLen > 0
         if (ctx->inputSeqLen >= 1024 && pastSeqLen == 0)
-            flashAttention(
-                    ctx, qkvGroupMatMul, resultBuffer2, resultBuffer1, presentKey, presentValue, attnMask, pastSeqLen);
+            flashAttention(ctx, qkvGroupMatMul, outBuffer, imBuffer, presentKey, presentValue, attnMask, pastSeqLen);
         else
-            fusedAttention(ctx, query, key, value, resultBuffer1, presentKey, presentValue, attnMask, pastSeqLen);
+            fusedAttention(ctx, query, key, value, imBuffer, presentKey, presentValue, attnMask, pastSeqLen);
         t4.release();
 
         // For multiple nodes inference, not the whole result buffer
-        hpj::Matrix<float> attnSplit(resultBuffer1.Data(), resultBuffer1.Rows(), qCols, resultBuffer1.Stride());
+        hpj::Matrix<ImT> attnSplit(imBuffer.Data(), imBuffer.Rows(), qCols, imBuffer.Stride());
 
 #ifdef DEBUG
         dbg.debugPrint("attention_%d (softmax * value): [%d, %d] (%d)\n", ctx->splitIdx, attnSplit.Rows(),
@@ -304,38 +297,38 @@ public:
             // So here still use denseWithSum
             if (gamma == 1) {
                 DecoderUtil::denseWithSum(attnSplit, attnOutputWeight, attnOutputWeightScale, attnOutputWeightZero,
-                        attnOutputWeightSum, attnOutputBias, inputBuffer, resultBuffer2);
+                        attnOutputWeightSum, attnOutputBias, inputBuffer, outBuffer);
             } else {
                 DecoderUtil::denseWithScaledSum(attnSplit, attnOutputWeight, attnOutputWeightScale,
-                        attnOutputWeightZero, attnOutputWeightSum, attnOutputBias, gamma, inputBuffer, resultBuffer2);
+                        attnOutputWeightZero, attnOutputWeightSum, attnOutputBias, gamma, inputBuffer, outBuffer);
             }
         } else {
             DecoderUtil::dense(attnSplit, attnOutputWeight, attnOutputWeightScale, attnOutputWeightZero,
-                    attnOutputWeightSum, attnOutputBias, resultBuffer2);
+                    attnOutputWeightSum, attnOutputBias, outBuffer);
         }
         t5.release();
 
 #ifdef DEBUG
         dbg.debugPrint("attention output/projection:\n");
-        dbg.dumpMatrix(resultBuffer2);
+        dbg.dumpMatrix(outBuffer);
 #endif
 
         if (!doLnBefore) {
             TimeLine t6("result.layer_norm");
-            norm.forward(resultBuffer2.Data(), resultBuffer2.Data(), resultBuffer2.Rows(), resultBuffer2.Stride(),
-                    resultBuffer2.Stride());
+            norm.forward(outBuffer.Data(), outBuffer.Data(), outBuffer.Rows(), outBuffer.Stride(), outBuffer.Stride());
 #ifdef DEBUG
-            dbg.debugPrint("LayerNorm after attention: [%d, %d] (%d)\n", resultBuffer2.Rows(), resultBuffer2.Cols(),
-                    resultBuffer2.Stride());
-            dbg.dumpMatrix(resultBuffer2);
+            dbg.debugPrint("LayerNorm after attention: [%d, %d] (%d)\n", outBuffer.Rows(), outBuffer.Cols(),
+                    outBuffer.Stride());
+            dbg.dumpMatrix(outBuffer);
 #endif
         }
     }
 
 protected:
+    // Note: the result here is still the intermediate result from the whole attention scope
     template <typename KVCacheT>
-    void fusedAttention(DecoderContext *ctx, hpj::Matrix<float> &query, hpj::Matrix<float> &key,
-            hpj::Matrix<float> &value, hpj::Matrix<float> &result, KVCacheTensor<KVCacheT> &presentKey,
+    void fusedAttention(DecoderContext *ctx, hpj::Matrix<ImT> &query, hpj::Matrix<ImT> &key,
+            hpj::Matrix<ImT> &value, hpj::Matrix<ImT> &result, KVCacheTensor<KVCacheT> &presentKey,
             KVCacheTensor<KVCacheT> &presentValue, const float *attnMask, int pastSeqLen) {
         // How many heads this task should do
         int responsibleHeads = this->endQHead - this->startQHead;
@@ -397,13 +390,8 @@ protected:
                         auto srcV = value.Row(b * ctx->inputSeqLen + seq) + i * ctx->attHeadSize;
                         auto dstV = presentValue.getSequence(pastSeqLen + seq, b, i);
 
-                        if constexpr (std::is_same_v<KVCacheT, float>) {
-                            memcpy(dstK, srcK, ctx->attHeadSize * sizeof(float));
-                            memcpy(dstV, srcV, ctx->attHeadSize * sizeof(float));
-                        } else if constexpr (std::is_same_v<KVCacheT, float16_t>) {
-                            float16_t::cvt_float_to_float16(srcK, dstK, ctx->attHeadSize);
-                            float16_t::cvt_float_to_float16(srcV, dstV, ctx->attHeadSize);
-                        }
+                        xft::copy(dstK, srcK, ctx->attHeadSize);
+                        xft::copy(dstV, srcV, ctx->attHeadSize);
                     }
                 }
             }
@@ -429,11 +417,7 @@ protected:
                         for (int seq = 0; seq < ctx->inputSeqLen; ++seq) {
                             auto src = key.Row(b * ctx->inputSeqLen + seq) + i * ctx->attHeadSize;
                             auto dst = presentKey.getSequence(pastSeqLen + seq, b, i);
-                            if constexpr (std::is_same_v<KVCacheT, float>) {
-                                memcpy(dst, src, ctx->attHeadSize * sizeof(float));
-                            } else if constexpr (std::is_same_v<KVCacheT, float16_t>) {
-                                float16_t::cvt_float_to_float16(src, dst, ctx->attHeadSize);
-                            }
+                            xft::copy(dst, src, ctx->attHeadSize);
                         }
                     }
 
@@ -514,11 +498,7 @@ protected:
                         for (int seq = 0; seq < ctx->inputSeqLen; ++seq) {
                             auto src = value.Row(b * ctx->inputSeqLen + seq) + i * ctx->attHeadSize;
                             auto dst = presentValue.getSequence(pastSeqLen + seq, b, i);
-                            if constexpr (std::is_same_v<KVCacheT, float>) {
-                                memcpy(dst, src, ctx->attHeadSize * sizeof(float));
-                            } else if constexpr (std::is_same_v<KVCacheT, float16_t>) {
-                                float16_t::cvt_float_to_float16(src, dst, ctx->attHeadSize);
-                            }
+                            xft::copy(dst, src, ctx->attHeadSize);
                         }
                     }
 
@@ -554,8 +534,8 @@ protected:
 
     // When #heads is very few, need to shard each head to use more resources
     template <typename KVCacheT>
-    void crossAttnShardHead(DecoderContext *ctx, hpj::Matrix<float> &query, hpj::Matrix<float> &key,
-            hpj::Matrix<float> &value, hpj::Matrix<float> &result, KVCacheTensor<KVCacheT> &presentKey,
+    void crossAttnShardHead(DecoderContext *ctx, hpj::Matrix<ImT> &query, hpj::Matrix<ImT> &key,
+            hpj::Matrix<ImT> &value, hpj::Matrix<ImT> &result, KVCacheTensor<KVCacheT> &presentKey,
             KVCacheTensor<KVCacheT> &presentValue, const float *attnMask, int pastSeqLen) {
         const int responsibleHeads = this->endQHead - this->startQHead;
         const int batchSize = ctx->batchSize;

--- a/src/layers/attn_baichuan.h
+++ b/src/layers/attn_baichuan.h
@@ -18,7 +18,7 @@
 #include <cstring>
 
 #include "common_decoder.h"
-#include "layers_norm.h"
+#include "rms_norm.h"
 #include "attention.h"
 
 template <typename WeiT, typename QKPO_CLS = QKPO_Dummy, typename NORM_CLS = RmsNorm>

--- a/src/layers/attn_chatglm.h
+++ b/src/layers/attn_chatglm.h
@@ -18,9 +18,10 @@
 #include "attention.h"
 
 template <typename WeiT, typename QKPO_CLS, typename NORM_CLS>
-class ChatGlmAttention : public Attention<WeiT, QKPO_CLS, NORM_CLS, false> {
+class ChatGlmAttention : public Attention<WeiT, QKPO_CLS, NORM_CLS, float, float, float, false> {
 public:
-    ChatGlmAttention(int layerId, DecoderContext *ctx) : Attention<WeiT, QKPO_CLS, NORM_CLS, false>(layerId, ctx) {
+    ChatGlmAttention(int layerId, DecoderContext *ctx)
+        : Attention<WeiT, QKPO_CLS, NORM_CLS, float, float, float, false>(layerId, ctx) {
         residScale = std::sqrt(2 * ctx->layers);
         scalingCoeff = 1.0f / (std::sqrt(ctx->attHeadSize) * (layerId + 1));
     }

--- a/src/layers/decoder_layer.h
+++ b/src/layers/decoder_layer.h
@@ -28,11 +28,25 @@
 #include <new>
 #include <sstream>
 #include <string>
+#include <type_traits>
 
 #include "attention.h"
 #include "debugger.h"
 #include "kvcache_tensor.h"
 #include "timeline.h"
+#include "type_selector.h"
+
+// To get weight data type in attention class
+template <typename T>
+struct AttnParameters;
+template <template <typename...> class ATTN_CLS, typename WeiT, typename QKPO_CLS, typename NORM_CLS>
+struct AttnParameters<ATTN_CLS<WeiT, QKPO_CLS, NORM_CLS>> {
+    using Tim = float;
+};
+template <typename WeiT, typename QKPO_CLS, typename NORM_CLS, typename InT, typename ImT, typename OutT>
+struct AttnParameters<Attention<WeiT, QKPO_CLS, NORM_CLS, InT, ImT, OutT, true>> {
+    using Tim = ImT;
+};
 
 template <typename ATTN_CLS, typename MLP_CLS>
 class Decoder {
@@ -74,13 +88,17 @@ public:
         mlp.setWeights(ctx, mlpParams, trans);
     }
 
-    template <typename KVCacheT>
-    void forwardAttention(DecoderContext *ctx, float *input, float *output, const float *attnMask, KVCacheTensor<KVCacheT> &presentKey,
-            KVCacheTensor<KVCacheT> &presentValue, int inputSeqLen, int pastSeqLen, bool useSelfAttn, bool doLnBefore,
-            bool returnAttn, bool returnKVs, bool forPT = true, int *positionIds = nullptr) {
+    template <typename InT, typename ImT, typename OutT, typename KVCacheT>
+    void forwardAttention(DecoderContext *ctx, InT *input, ImT *imBuf, OutT *output, const float *attnMask,
+            KVCacheTensor<KVCacheT> &presentKey, KVCacheTensor<KVCacheT> &presentValue, int inputSeqLen, int pastSeqLen,
+            bool useSelfAttn, bool doLnBefore, int *positionIds = nullptr) {
         TimeLine t("Decoder.forwardAttention");
-        attn.forward(ctx, input, output, attnMask, presentKey, presentValue, inputSeqLen, pastSeqLen, useSelfAttn,
-                doLnBefore, returnAttn, returnKVs, forPT, positionIds);
+
+        using Ttarget = typename AttnParameters<ATTN_CLS>::Tim;
+        static_assert(sizeof(ImT) >= sizeof(Ttarget), "Intermediate buffer is NOT big enough!");
+
+        attn.forward(ctx, input, (Ttarget *)imBuf, output, attnMask, presentKey, presentValue, inputSeqLen, pastSeqLen,
+                useSelfAttn, doLnBefore, positionIds);
     }
 
     void forwardFFN(DecoderContext *ctx, float *input, float *output, int iStride, int oStride, bool doLnBefore = true) {

--- a/src/layers/layer_norm.cpp
+++ b/src/layers/layer_norm.cpp
@@ -18,7 +18,7 @@
 #include <cstring>
 
 #include "layernorm_kernels.h"
-#include "layers_norm.h"
+#include "layer_norm.h"
 #include "timeline.h"
 
 namespace xft {

--- a/src/layers/layer_norm.h
+++ b/src/layers/layer_norm.h
@@ -14,14 +14,25 @@
 // ============================================================================
 #pragma once
 
-#include "dtype.h"
-
 namespace xft {
 
-void invokeLayerNorm(DataType dt, void *output, const void *input, const void *gamma, const void *beta, int rows,
-        int cols, int iStride = -1, int oStride = -1, float epsilon = 1e-5);
+// Layer normalization: only support the norm along last dimension
+class LayerNorm {
+public:
+    LayerNorm();
+    ~LayerNorm();
 
-void invokeRmsNorm(DataType dt, void *output, const void *input, const void *weight, int rows, int cols,
-        int iStride = -1, int oStride = -1, float epsilon = 1e-6);
+    void setWeight(const float *gamma, const float *beta, int cols);
+
+    // input and output are in shape of (rows, normSize)
+    // TODO: column-wise parallel
+    void forward(const float *input, float *output, int rows, int iStride = -1, int oStride = -1, float epsilon = 1e-5);
+
+private:
+    int normSize;
+
+    // the weights contains gamma and beta concated together
+    float *weights;
+};
 
 } // namespace xft

--- a/src/layers/rms_norm.cpp
+++ b/src/layers/rms_norm.cpp
@@ -17,7 +17,7 @@
 #include <cstdlib>
 #include <cstring>
 
-#include "layers_norm.h"
+#include "rms_norm.h"
 #include "rmsnorm_kernels.h"
 #include "timeline.h"
 
@@ -41,7 +41,12 @@ void RmsNorm::setWeight(const float *w, const float *, int cols) {
 // input and output are in shape of (rows, normSize)
 void RmsNorm::forward(const float *input, float *output, int rows, int iStride, int oStride, float epsilon) {
     TimeLine t("RmsNorm.forward");
-    invokeRmsNorm(output, input, weight, rows, normSize, iStride, oStride, epsilon);
+    rmsNorm(output, input, weight, rows, normSize, iStride, oStride, epsilon);
+}
+
+void RmsNorm::forward(const float *input, bfloat16_t *output, int rows, int iStride, int oStride, float epsilon) {
+    TimeLine t("RmsNorm.forward");
+    rmsNorm(output, input, weight, rows, normSize, iStride, oStride, epsilon);
 }
 
 } // namespace xft

--- a/src/layers/rms_norm.h
+++ b/src/layers/rms_norm.h
@@ -14,14 +14,29 @@
 // ============================================================================
 #pragma once
 
-#include "dtype.h"
+#include "bfloat16.h"
 
 namespace xft {
 
-void invokeLayerNorm(DataType dt, void *output, const void *input, const void *gamma, const void *beta, int rows,
-        int cols, int iStride = -1, int oStride = -1, float epsilon = 1e-5);
+// RMS normalization: only support the norm along last dimension
+class RmsNorm {
+public:
+    RmsNorm();
+    ~RmsNorm();
 
-void invokeRmsNorm(DataType dt, void *output, const void *input, const void *weight, int rows, int cols,
-        int iStride = -1, int oStride = -1, float epsilon = 1e-6);
+    void setWeight(const float *w, const float *, int cols);
+
+    // Input and output are in shape of (rows, normSize)
+    void forward(const float *input, float *output, int rows, int iStride = -1, int oStride = -1, float epsilon = 1e-6);
+
+    // Input = float, output = bfloat16_t
+    void forward(const float *input, bfloat16_t *output, int rows, int iStride = -1, int oStride = -1, float epsilon = 1e-6);
+
+private:
+    int normSize;
+
+    // the scale weight
+    float *weight;
+};
 
 } // namespace xft

--- a/src/models/chatglm.h
+++ b/src/models/chatglm.h
@@ -17,7 +17,7 @@
 #include <vector>
 #include "attn_chatglm.h"
 #include "common_decoder.h"
-#include "layers_norm.h"
+#include "layer_norm.h"
 #include "mlp_chatglm.h"
 #include "rope_2d.h"
 #include "token_embedding.h"

--- a/src/models/chatglm2.cpp
+++ b/src/models/chatglm2.cpp
@@ -20,8 +20,8 @@
 
 template <typename WeiT, typename NormT>
 ChatGLM2<WeiT, NormT>::ChatGLM2(const std::string &modelPath, const std::string &modelType)
-    : CommonDecoder<Attention<WeiT, ChatGLM2RotaryEmbedding, NormT, true>, ChatGLM2MLP<WeiT, NormT, true>>(
-            modelPath, modelType) {
+    : CommonDecoder<Attention<WeiT, ChatGLM2RotaryEmbedding, NormT, float, float, float, true>,
+            ChatGLM2MLP<WeiT, NormT, true>>(modelPath, modelType) {
     this->positionIds = nullptr;
     this->posBufSize = 0;
 

--- a/src/models/chatglm2.h
+++ b/src/models/chatglm2.h
@@ -17,14 +17,14 @@
 #include <vector>
 #include "attention.h"
 #include "common_decoder.h"
-#include "layers_norm.h"
 #include "mlp_chatglm2.h"
+#include "rms_norm.h"
 #include "rotary_embedding_chatglm2.h"
 #include "token_embedding.h"
 
 template <typename WeiT, typename NormT = RmsNorm>
-class ChatGLM2
-    : public CommonDecoder<Attention<WeiT, ChatGLM2RotaryEmbedding, NormT, true>, ChatGLM2MLP<WeiT, NormT, true>> {
+class ChatGLM2 : public CommonDecoder<Attention<WeiT, ChatGLM2RotaryEmbedding, NormT, float, float, float, true>,
+                         ChatGLM2MLP<WeiT, NormT, true>> {
 public:
     ChatGLM2(const std::string &modelPath, const std::string &modelType = "chatglm2");
     ~ChatGLM2();

--- a/src/models/common_decoder.h
+++ b/src/models/common_decoder.h
@@ -197,22 +197,20 @@ public:
             KVCacheTensor<KVCacheT> &presentKey = this->kvCacheMgr->getKey(i);
             KVCacheTensor<KVCacheT> &presentValue = this->kvCacheMgr->getValue(i);
 
-            this->decoders[i]->forwardAttention(getContext(), this->embBuf->Data(), this->outBuf->Data(), attnMask,
+            // Pls be noted: in attention, 'outBuf' is used as imtermediate buffer, 'tmpBuf' is used as output
+            auto &attnOut = this->getContext()->tmpBuf;
+            this->decoders[i]->forwardAttention(getContext(), this->embBuf->Data(), this->outBuf->Data(),
+                    attnOut.Data(), attnMask,
                     presentKey, // presentKey,
                     presentValue, // presentValue,
                     inputSeqLen, // inputSeqLen,
                     pastSeqLen, // pastSeqLen
                     step == 0, // useSelfAttn,
                     true, // doLnBefore,
-                    false, // returnAttn,
-                    false, // returnKVs
-                    false, // forPT
                     positionIds);
 
             // Expand the KV cache as it only has values for beam 0
             if (step == 0 && beamSize > 1) { this->kvCacheMgr->expandCache(i, userSideBS, beamSize, seqLen); }
-
-            auto &attnOut = this->getContext()->tmpBuf;
 
             // Merge the result of attention
             // When attention and FFN/MLP are in parallel, do not need to reduce after attention
@@ -347,19 +345,17 @@ public:
             KVCacheTensor<KVCacheT> &presentKey = this->kvCacheMgr->getPrefixKey(i);
             KVCacheTensor<KVCacheT> &presentValue = this->kvCacheMgr->getPrefixValue(i);
 
-            this->decoders[i]->forwardAttention(getContext(), this->embBuf->Data(), this->outBuf->Data(), attnMask,
+            // Pls be noted: in attention, 'outBuf' is used as imtermediate buffer, 'tmpBuf' is used as output
+            auto &attnOut = this->getContext()->tmpBuf;
+            this->decoders[i]->forwardAttention(getContext(), this->embBuf->Data(), this->outBuf->Data(),
+                    attnOut.Data(), attnMask,
                     presentKey, // presentKey,
                     presentValue, // presentValue,
                     seqLen, // inputSeqLen,
                     0, // pastSeqLen
                     true, // useSelfAttn,
                     true, // doLnBefore,
-                    false, // returnAttn,
-                    false, // returnKVs
-                    false, // forPT
                     positionIds);
-
-            auto &attnOut = this->getContext()->tmpBuf;
 
             // Merge the result of attention
             // When attention and FFN/MLP are in parallel, do not need to reduce after attention

--- a/src/models/llama.cpp
+++ b/src/models/llama.cpp
@@ -18,7 +18,9 @@
 
 template <typename WeiT>
 LlamaLLM<WeiT>::LlamaLLM(const std::string &modelPath)
-    : CommonDecoder<Attention<WeiT, LlamaRotaryEmbedding, RmsNorm>, LlamaMLP<WeiT>, float>(modelPath, "llama") {
+    : CommonDecoder<
+            Attention<WeiT, LlamaRotaryEmbedding, RmsNorm, float, typename TypeSelector<WeiT>::ImType, float, true>,
+            LlamaMLP<WeiT>, float>(modelPath, "llama") {
     // Context
     DecoderContext *ctx = this->getContext();
 

--- a/src/models/llama.h
+++ b/src/models/llama.h
@@ -16,12 +16,16 @@
 
 #include "common_decoder.h"
 #include "mlp_llama.h"
-#include "layers_norm.h"
+#include "rms_norm.h"
+#include "type_selector.h"
 #include "rotary_embedding.h"
 #include "token_embedding.h"
 
 template <typename WeiT>
-class LlamaLLM : public CommonDecoder<Attention<WeiT, LlamaRotaryEmbedding, RmsNorm>, LlamaMLP<WeiT>, float> {
+class LlamaLLM
+    : public CommonDecoder<
+              Attention<WeiT, LlamaRotaryEmbedding, RmsNorm, float, typename TypeSelector<WeiT>::ImType, float, true>,
+              LlamaMLP<WeiT>, float> {
 public:
     LlamaLLM(const std::string &modelPath);
     ~LlamaLLM();

--- a/src/models/opt_decoder.h
+++ b/src/models/opt_decoder.h
@@ -22,7 +22,7 @@
 #include "common_decoder.h"
 #include "dist_linear.h"
 #include "float16.h"
-#include "layers_norm.h"
+#include "layer_norm.h"
 #include "messenger.h"
 #include "mlp_standard.h"
 #include "opt_embedding.h"

--- a/src/models/qwen.h
+++ b/src/models/qwen.h
@@ -16,7 +16,7 @@
 
 #include "common_decoder.h"
 #include "mlp_llama.h"
-#include "layers_norm.h"
+#include "rms_norm.h"
 #include "rotary_embedding.h"
 #include "token_embedding.h"
 

--- a/src/utils/copy_util.h
+++ b/src/utils/copy_util.h
@@ -20,25 +20,25 @@ void copy(T1 *dst, T2 *src, int size) {
 
 // Specialization for T1=float, T2=float16_t
 template <>
-void copy(float *dst, float16_t *src, int size) {
+inline void copy(float *dst, float16_t *src, int size) {
     float16_t::cvt_float16_to_float(src, dst, size);
 }
 
 // Specialization for T1=float16_t, T2=float
 template <>
-void copy(float16_t *dst, float *src, int size) {
+inline void copy(float16_t *dst, float *src, int size) {
     float16_t::cvt_float_to_float16(src, dst, size);
 }
 
 // Specialization for T1=float, T2=bloat16_t
 template <>
-void copy(float *dst, bfloat16_t *src, int size) {
+inline void copy(float *dst, bfloat16_t *src, int size) {
     bfloat16_t::cvt_bfloat16_to_float(src, dst, size);
 }
 
 // Specialization for T1=boat16_t, T2=float
 template <>
-void copy(bfloat16_t *dst, float *src, int size) {
+inline void copy(bfloat16_t *dst, float *src, int size) {
     bfloat16_t::cvt_float_to_bfloat16(src, dst, size);
 }
 

--- a/src/utils/decoder_util.h
+++ b/src/utils/decoder_util.h
@@ -30,17 +30,17 @@
 class DecoderUtil {
 public:
     // Dense without bias
-    template <typename WeiT>
-    static void dense(hpj::Matrix<float> &x, hpj::Matrix<WeiT> &weight, hpj::Vector<float> &scaleWeight,
-            hpj::Vector<float> &zeroWeight, hpj::Vector<float> &sumWeight, hpj::Matrix<float> &result) {
+    template <typename InT, typename WeiT, typename OutT>
+    static void dense(hpj::Matrix<InT> &x, hpj::Matrix<WeiT> &weight, hpj::Vector<float> &scaleWeight,
+            hpj::Vector<float> &zeroWeight, hpj::Vector<float> &sumWeight, hpj::Matrix<OutT> &result) {
         MMHelper::compute(false, x.Rows(), weight.Cols(), x.Cols(), 1.0f, x.Data(), x.Stride(), weight.Data(),
                 scaleWeight.Data(), zeroWeight.Data(), sumWeight.Data(), 0.0f, result.Data(), result.Stride());
     }
 
-    template <typename WeiT>
-    static void dense(hpj::Matrix<float> &x, hpj::Matrix<WeiT> &weight, hpj::Vector<float> &scaleWeight,
+    template <typename InT, typename WeiT, typename OutT>
+    static void dense(hpj::Matrix<InT> &x, hpj::Matrix<WeiT> &weight, hpj::Vector<float> &scaleWeight,
             hpj::Vector<float> &zeroWeight, hpj::Vector<float> &sumWeight, hpj::Vector<float> &bias,
-            hpj::Matrix<float> &result) {
+            hpj::Matrix<OutT> &result) {
         REQUIRES(x.Cols() == weight.Rows(), "dense error: x.Cols (%d) != weight.Rows (%d)", x.Cols(), weight.Rows());
         REQUIRES(x.Rows() == result.Rows(), "dense error: x.Rows (%d) != result.Rows (%d)", x.Rows(), result.Rows());
         REQUIRES(weight.Cols() == result.Cols(), "dense error: weight.Cols (%d) != result.Cols (%d)", weight.Cols(),

--- a/src/utils/type_selector.h
+++ b/src/utils/type_selector.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "bfloat16.h"
+
+// Selected data types according to weight data type
+template <typename WeiT>
+struct TypeSelector {
+    using InType = float;
+    using ImType = float; // intermediate data type, default in float
+    using OutType = float;
+};
+
+// Specialization for bfloat16_t
+template <>
+struct TypeSelector<bfloat16_t> {
+    using InType = float;
+    // TODO: change it to bfloat16_t, make it work and verify the accuray
+    using ImType = float;
+    using OutType = float;
+};


### PR DESCRIPTION
- Export InT, ImT, OutT in Attention
- Remove unused params in forwardAttention
- Move LayerNorm/RmsNorm class definition from include to layers
- Make RmsNorm supprort FP32 in, BF16 out.
- Correct GCC version for AVX512BF16