### PR TITLE
[models][layers/tools] Refine and bugfix for baichuan models

### DIFF
--- a/src/models/baichuan.h
+++ b/src/models/baichuan.h
@@ -16,8 +16,8 @@
 
 #include "attn_baichuan.h"
 #include "common_decoder.h"
-#include "mlp_llama.h"
 #include "layers_norm.h"
+#include "mlp_llama.h"
 #include "rotary_embedding.h"
 #include "token_embedding.h"
 
@@ -27,6 +27,7 @@ public:
     Baichuan(const std::string &modelPath);
     ~Baichuan();
 
+    void prepareAttnMaskBase(int *ids, int step);
     void prepareAttnMask(int *ids, int step);
     void embeddingForward(int *ids, float *output, int batchSize, int seqLen);
     void lastLayerNormForward(float *input, float *output, int rows);

--- a/src/xfastertransformer/tools/baichuan_convert.py
+++ b/src/xfastertransformer/tools/baichuan_convert.py
@@ -16,6 +16,7 @@ import configparser
 import multiprocessing
 import numpy as np
 import os
+from torch import nn
 
 from transformers import AutoModelForCausalLM
 
@@ -147,7 +148,7 @@ class BaichuanConvert(BaseModelConvert):
             if "embed" in name:
                 model_named_parameters[name] = param
             elif "lm_head" in name:
-                model_named_parameters[name] = param
+                model_named_parameters[name] = nn.functional.normalize(param)
             else:
                 model_named_parameters[name] = param.permute(1, 0) if len(param.shape) == 2 else param
 


### PR DESCRIPTION
Fix the bug reported by issue #209 

For Baichuan2-13B-Chat v2.0
input prompt:
prompt ="""已知信息：
了 label smoothing 和 mixup 微调之后的模型做了权重上的线性加权。实验结果如
表 3.2 所示。结果表明，BANG 算法有效的提高了 WiSE-FT 算法的效果。特别的，
BANG(LS+Mixup)在五个OOD数据集上比现有的最优算法WiSE-FT高出1.9%。
表3.2 在ImageNet上微调ViT-B/16的效果
Methods ModelAveraging IN IN-V2 IN-R IN-A IN-S ObjectNet AvgOOD

ZIN 与现有的几种方法进行了比较:ERM、IRM[58]、EIIL[71]、HRM[70]和 LfF[81]。
对于IRM，本文提供了ground-truth环境划分，并将其性能作为一个上界。LfF试
图通过从错误指定的浅层神经网络样本中直接采用 boosting 来学习一个鲁棒的模
型。而且LfF仅适用于分类任务。
5.4.1 房价预测任务
本实验考虑了来自Kaggle的真实房屋销售价格回归数据集。目标变量是房价，
每个样本包含17维度的特征，如房子的建成年份、卧室数量等。数据集根据构建

BANG(Mixup+LS) Yes 81.6 73.1 79.7 58.2 54.8 58.9 64.9
3.5 小结
本节研究了为什么集成算法具有优越的 OOD 性能。对 WiSE-FT 的实证分析，
加上理论见解，表明虚假特征的多样化改善了模型的泛化性能。进一步的，笔者通
过缓解微调模型的过度自信问题改进了WiSE-FT。
20 
根据上述已知信息，简洁和专业的来回答用户的问题。如果无法从中得到答案，
请说 “根据已知信息无法回答该问题” 或 “没有提供足够的相关信息”，不允许在答案中添加编造成分，答案请使用中文。 
问题是：langchain中stuff作用是什么？,答案："""

xFT BF16 outp
<img width="1074" alt="MobaXterm_QIrhYhwWXD" src="https://github.com/intel/xFasterTransformer/assets/29789552/44f8ee79-f0d2-4860-803a-c129e9cbac27">

It is the same as pytorch （float）

