### PR TITLE
[Env] Add XFT_ENGINE env variable.

### DIFF
--- a/src/comm_helper/comm_helper.cpp
+++ b/src/comm_helper/comm_helper.cpp
@@ -28,7 +28,7 @@ extern "C" int init(int *world_size, int *world_rank, int *world_color) {
     MPI_Comm_rank(MPI_COMM_WORLD, world_rank);
 
     // world_color = world_rank / tpSize = world_rank / (world_size / ppSize)
-    // like: world_color = 0~7 / (8 / 4), XFT_PIPELINE_STAGES = ppSize = 4; tpSize = 2
+    // like: world_color = 0~7 / (8 / 4), XFT_PIPELINE_STAGE = ppSize = 4; tpSize = 2
     //       world_rank = 0, 1,  ->  world_color = ppRank = 0, 0,  ->  tpRank = 0, 1;
     //                    2, 3,                             1, 1,               0, 1;
     //                    4, 5,                             2, 2,               0, 1;

--- a/src/models/common_decoder.h
+++ b/src/models/common_decoder.h
@@ -614,7 +614,15 @@ protected:
             this->context.reset(new DecoderContext(layers, hiddenSize, attHeadNum, kvHeadNum, imSize, act, epsilon,
                     vocabSize, embeddingSize, maxPositions, maxPosEmbed, maxSeqLength, tpRank, tpSize, ppSize, ppRank,
                     ropeParamsPtr));
-            this->context->mmHelper = new MMHelper(xft::DeviceKind::iCPU, 0);
+
+            if (Env::getEngineKind() == xft::DeviceKind::iCPU)
+                this->context->mmHelper = new MMHelper(xft::DeviceKind::iCPU, Env::getEngineIndex());
+            else if (Env::getEngineKind() == xft::DeviceKind::iGPU)
+                this->context->mmHelper = new MMHelper(xft::DeviceKind::iGPU, Env::getEngineIndex());
+            else{
+                printf("[ERROR] Undefined device kind in XFT_ENGINE.\n");
+                exit(-1);
+            }
         }
 
         return this->context.get();

--- a/src/models/common_decoder.h
+++ b/src/models/common_decoder.h
@@ -615,9 +615,9 @@ protected:
                     vocabSize, embeddingSize, maxPositions, maxPosEmbed, maxSeqLength, tpRank, tpSize, ppSize, ppRank,
                     ropeParamsPtr));
 
-            if (Env::getEngineKind() == xft::DeviceKind::iGPU && Env::getEngineIndex() < 0)
+            if (Env::getEngineKind() == xft::DeviceKind::iGPU && Env::getEngineIndex() < 0) // Sequential assignment
                 this->context->mmHelper = new MMHelper(Env::getEngineKind(), ppRank * tpSize + tpRank);
-            else
+            else // assignment through the user
                 this->context->mmHelper = new MMHelper(Env::getEngineKind(), Env::getEngineIndex());
         }
 

--- a/src/models/common_decoder.h
+++ b/src/models/common_decoder.h
@@ -67,7 +67,7 @@ struct MlpTypeExtractor<ChatGLM2MLP<WeiT, InT, ImT, OutT, NORM_CLS, true>> {
 /*
 Pipeline parallel and tensor parallel introduction:
 
-  1) MPI_Instances = 16,XFT_PIPELINE_STAGES = 4  =>  ctx->ppSize = 4, ctx->tpSize = 4
+  1) MPI_Instances = 16,XFT_PIPELINE_STAGE = 4  =>  ctx->ppSize = 4, ctx->tpSize = 4
   2) TP sync by oneCCL(row_comm) or shared_memory
   3) PP sync by MPI MPI_COMM_WORLD
 

--- a/src/models/common_decoder.h
+++ b/src/models/common_decoder.h
@@ -615,7 +615,6 @@ protected:
                     vocabSize, embeddingSize, maxPositions, maxPosEmbed, maxSeqLength, tpRank, tpSize, ppSize, ppRank,
                     ropeParamsPtr));
 
-            printf("Engine: %d:%d\n", Env::getEngineKind(), Env::getEngineIndex());
             if (Env::getEngineKind() == xft::DeviceKind::iGPU && Env::getEngineIndex() < 0)
                 this->context->mmHelper = new MMHelper(Env::getEngineKind(), ppRank * tpSize + tpRank);
             else

--- a/src/models/common_decoder.h
+++ b/src/models/common_decoder.h
@@ -615,14 +615,11 @@ protected:
                     vocabSize, embeddingSize, maxPositions, maxPosEmbed, maxSeqLength, tpRank, tpSize, ppSize, ppRank,
                     ropeParamsPtr));
 
-            if (Env::getEngineKind() == xft::DeviceKind::iCPU)
-                this->context->mmHelper = new MMHelper(xft::DeviceKind::iCPU, Env::getEngineIndex());
-            else if (Env::getEngineKind() == xft::DeviceKind::iGPU)
-                this->context->mmHelper = new MMHelper(xft::DeviceKind::iGPU, Env::getEngineIndex());
-            else {
-                printf("[ERROR] Undefined device kind in XFT_ENGINE.\n");
-                exit(-1);
-            }
+            printf("Engine: %d:%d\n", Env::getEngineKind(), Env::getEngineIndex());
+            if (Env::getEngineKind() == xft::DeviceKind::iGPU && Env::getEngineIndex() < 0)
+                this->context->mmHelper = new MMHelper(Env::getEngineKind(), ppRank * tpSize + tpRank);
+            else
+                this->context->mmHelper = new MMHelper(Env::getEngineKind(), Env::getEngineIndex());
         }
 
         return this->context.get();

--- a/src/models/common_decoder.h
+++ b/src/models/common_decoder.h
@@ -619,7 +619,7 @@ protected:
                 this->context->mmHelper = new MMHelper(xft::DeviceKind::iCPU, Env::getEngineIndex());
             else if (Env::getEngineKind() == xft::DeviceKind::iGPU)
                 this->context->mmHelper = new MMHelper(xft::DeviceKind::iGPU, Env::getEngineIndex());
-            else{
+            else {
                 printf("[ERROR] Undefined device kind in XFT_ENGINE.\n");
                 exit(-1);
             }

--- a/src/models/models.cpp
+++ b/src/models/models.cpp
@@ -52,6 +52,7 @@ GenerationMode getGenerationMode(SearcherConfig &config_) {
 Model::Model() : decoder(nullptr), searcher(nullptr), isNewInput(true) {
     Env::initVerbose();
     Env::initPipelineStage();
+    Env::initEngineKindIndex();
     TimeLine::init();
 }
 

--- a/src/utils/verbose.h
+++ b/src/utils/verbose.h
@@ -85,16 +85,16 @@ private:
 
 public:
     static void initPipelineStage() {
-        char *xft_pipeline_value = getenv("XFT_PIPELINE_STAGES");
+        char *xft_pipeline_value = getenv("XFT_PIPELINE_STAGE");
         if (xft_pipeline_value != NULL) {
 #ifdef PIPELINE_PARALLEL
             int value = atoi(xft_pipeline_value);
             if (value >= 1)
                 pipelineStageValue() = value;
             else
-                printf("[ERROR] XFT_PIPELINE_STAGES value need to be greater than 0.\n");
+                printf("[ERROR] XFT_PIPELINE_STAGE value need to be greater than 0.\n");
 #else
-            printf("[WARNING] XFT_PIPELINE_STAGES need to build with WITH_PIPELINE_PARALLEL=ON.\n");
+            printf("[WARNING] XFT_PIPELINE_STAGE need to build with WITH_PIPELINE_PARALLEL=ON.\n");
 #endif
         } else {
             pipelineStageValue() = 1;

--- a/src/utils/verbose.h
+++ b/src/utils/verbose.h
@@ -132,13 +132,18 @@ public:
                     engineKindValue() = xft::DeviceKind::iGPU;
                 else
                     printf("[ERROR] Undefined device kind in XFT_ENGINE.\n");
+            } else {
+                printf("[ERROR] Wrong value: XFT_ENGINE.\n");
             }
+
             if (std::getline(ss, token, ':')) {
                 int value = std::stoi(token);
                 if (value >= 0)
                     engineIndexValue() = value;
                 else
                     printf("[ERROR] Undefined device index in XFT_ENGINE.\n");
+            } else {
+                engineIndexValue() = -1;
             }
         } else {
             engineKindValue() = xft::DeviceKind::iCPU;


### PR DESCRIPTION
There are 2 methods to assign GPU cards to map into MPI processes.

Method 1) Assign Sequentially(`XFT_ENGINE=GPU`), like MPI process 0 maps to GPU card 0, MPI process 1 maps to GPU card 1...
```bash
XFT_ENGINE=GPU XFT_PIPELINE_STAGE=1 OMP_NUM_THREADS=12 ENABLE_CAT_MLP=1 mpirun \
    -n 1 numactl --all -C 48-59 -m 1 ./example --model /data/qwen-1_8b-xft/ --token /data/qwen-1_8b-hf/tokenizer_config.json --dtype fp16 --loop 1 --input_len 16 --output_len 16 : \
    -n 1 numactl --all -C 60-71 -m 1 ./example --model /data/qwen-1_8b-xft/ --token /data/qwen-1_8b-hf/tokenizer_config.json --dtype fp16 --loop 1 --input_len 16 --output_len 16 : \
    -n 1 numactl --all -C 72-83 -m 1 ./example --model /data/qwen-1_8b-xft/ --token /data/qwen-1_8b-hf/tokenizer_config.json --dtype fp16 --loop 1 --input_len 16 --output_len 16 : \
    -n 1 numactl --all -C 84-95 -m 1 ./example --model /data/qwen-1_8b-xft/ --token /data/qwen-1_8b-hf/tokenizer_config.json --dtype fp16 --loop 1 --input_len 16 --output_len 16
```
Method 2) Assign through the user define(`-env XFT_ENGINE=GPU:<N>`):
```bash
XFT_PIPELINE_STAGE=1 OMP_NUM_THREADS=12 ENABLE_CAT_MLP=1 mpirun \
    -n 1 -env XFT_ENGINE=GPU:0 numactl --all -C 48-59 -m 1 ./example --model /data/qwen-1_8b-xft/ --token /data/qwen-1_8b-hf/tokenizer_config.json --dtype fp16 --loop 1 --input_len 16 --output_len 16 : \
    -n 1 -env XFT_ENGINE=GPU:1 numactl --all -C 60-71 -m 1 ./example --model /data/qwen-1_8b-xft/ --token /data/qwen-1_8b-hf/tokenizer_config.json --dtype fp16 --loop 1 --input_len 16 --output_len 16 : \
    -n 1 -env XFT_ENGINE=GPU:2 numactl --all -C 72-83 -m 1 ./example --model /data/qwen-1_8b-xft/ --token /data/qwen-1_8b-hf/tokenizer_config.json --dtype fp16 --loop 1 --input_len 16 --output_len 16 : \
    -n 1 -env XFT_ENGINE=GPU:3 numactl --all -C 84-95 -m 1 ./example --model /data/qwen-1_8b-xft/ --token /data/qwen-1_8b-hf/tokenizer_config.json --dtype fp16 --loop 1 --input_len 16 --output_len 16
```