### PR TITLE
[Fix] Add parameter check for logN and NTK rotary embedding of QWEN

### DIFF
--- a/src/layers/rotary_embedding_qwen.cpp
+++ b/src/layers/rotary_embedding_qwen.cpp
@@ -66,6 +66,8 @@ void QwenRotaryEmbedding::init_logn(const int max_seq_length) {
             for i in range(1, 32768)
         ]
         */
+        REQUIRES(max_seq_length > 0 && max_seq_length < maxSupportedSeqLength,
+                "seq_length in config.ini is error, please re-conv the model with the latest convert tools");
         logn = (float *)malloc(maxSupportedSeqLength * sizeof(float));
 #pragma omp parallel for
         for (size_t i = 0; i < max_seq_length; i++) {

--- a/src/layers/rotary_embedding_qwen.cpp
+++ b/src/layers/rotary_embedding_qwen.cpp
@@ -67,7 +67,7 @@ void QwenRotaryEmbedding::init_logn(const int max_seq_length) {
         ]
         */
         REQUIRES(max_seq_length > 0 && max_seq_length < maxSupportedSeqLength,
-                "seq_length in config.ini is error, please re-conv the model with the latest convert tools");
+                "seq_length in config.ini is incorrect, please re-conv the model with the latest convert tools");
         logn = (float *)malloc(maxSupportedSeqLength * sizeof(float));
 #pragma omp parallel for
         for (size_t i = 0; i < max_seq_length; i++) {


### PR DESCRIPTION
Link with the Issue #229 Qwen Segmentation Fault after logN PR merged.
