### PR TITLE
Add KVCache trans for long sequence && tuned comm for faster Addreduce

### DIFF
--- a/benchmark/run_benchmark.sh
+++ b/benchmark/run_benchmark.sh
@@ -145,6 +145,18 @@ if [ -n $csv ]; then
     benchmark_cmd+=" --csv=$csv"
 fi
 
+if [[ ${model_name} == *"baichuan"* ]]; then
+    export FLASH_ATTN_THRESHOLD=1000
+fi
+
+if [[ ${beam_width} -eq 1 ]] && [[ ${input_tokens} -ge 1024 ]]; then
+    export ENABLE_KV_TRANS=1
+fi
+
+if [[ ${input_tokens} -ge 2048 ]]; then
+    export ENABLE_SKIP_MASK=1
+fi
+
 sockets_num=$(lscpu | grep "Socket(s)" | awk -F ':' '{print $2}')
 cores_per_socket=$(lscpu | grep "Core(s) per socket" | awk -F ':' '{print $2}')
 numa_nodes=$(lscpu | grep "NUMA node(s)" | awk -F ':' '{print $2}')

--- a/src/common/kvcache_tensor.h
+++ b/src/common/kvcache_tensor.h
@@ -21,6 +21,8 @@
 
 #include "allocator.h"
 
+extern bool kvTrans();
+
 /**
  * Tensor specially designed for KV Cache
  * Naturaly, it could be represented in the shape of [seq_length][batch_size][head_num][head_size]
@@ -32,7 +34,7 @@
  *  ...   |       |       |       |  ...  |       |       |       |
  *        |       |       |       |  ...  |       |       |       |
  *        `````````````````````````````````````````````````````````
- * For better performance, it can be represented as [batch_size][head_num][seq_length][head_size]
+ * For better performance (export ENABLE_KV_TRANS=1), it can be represented as [batch_size][head_num][seq_length][head_size]
  *        __________________
  *        |       |       ^
  *        |       |       |
@@ -92,13 +94,28 @@ public:
 
     // Get a vector for a specified sequence
     T *getSequence(int seqIdx, int batchIdx, int headIdx) {
-        return data + (seqIdx * batchSize + batchIdx) * (headNum * headSize) + headIdx * headSize;
+        if (kvTrans()) {
+            // [batchSize, headNum, seq, headSize] but also need to modify expand and reorder function
+            return data + (uint64_t)batchIdx * headNum * maxSeqLen * headSize + (uint64_t)headIdx * maxSeqLen * headSize
+                    + (uint64_t)seqIdx * headSize;
+        } else {
+            // [seqLen, batchSize, headNum, headSize] but also need to modify expand and reorder function
+            return data + (uint64_t)seqIdx * batchSize * headNum * headSize + (uint64_t)batchIdx * headNum * headSize
+                    + (uint64_t)headIdx * headSize;
+        }
     }
 
     // Get a head matrix, return the start address and the stride
     std::pair<T *, int> getHead(int batchIdx, int headIdx) {
-        T *addr = data + batchIdx * headNum * headSize + headIdx * headSize;
-        return std::make_pair(addr, batchSize * headNum * headSize);
+        if (kvTrans()) {
+            // [batchSize, headNum, seq, headSize] but also need to modify expand and reorder function
+            T *addr = data + batchIdx * headNum * maxSeqLen * headSize + headIdx * maxSeqLen * headSize;
+            return std::make_pair(addr, headSize);
+        } else {
+            // [seqLen, batchSize, headNum, headSize] but also need to modify expand and reorder function
+            T *addr = data + (uint64_t)batchIdx * headNum * headSize + (uint64_t)headIdx * headSize;
+            return std::make_pair(addr, batchSize * headNum * headSize);
+        }
     }
 
     /**
@@ -120,36 +137,33 @@ public:
             return;
         }
 
+        if (!kvTrans()) {
 #pragma omp parallel for
-        for (int seq = 0; seq < seqLen; ++seq) {
-            for (int b = batchSize - 1; b > 0; --b) {
-                T *dst = getSequence(seq, b, 0);
-                T *src = getSequence(seq, b / beamSize, 0);
-                memcpy(dst, src, headNum * headSize * sizeof(T));
+            for (int seq = 0; seq < seqLen; ++seq) {
+                for (int b = batchSize - 1; b > 0; --b) {
+                    T *dst = getSequence(seq, b, 0);
+                    T *src = getSequence(seq, b / beamSize, 0);
+                    memcpy(dst, src, sizeof(T) * headNum * headSize);
+                }
             }
+        } else {
+            printf("Unsupported kv tensor optimization [ENABLE_KV_TRANS] in beam search for now.\n");
+            exit(-1);
         }
     }
 
     void expandOneSequence(int userSideBS, int beamSize, int seq) {
-        for (int b = batchSize - 1; b > 0; --b) {
-            T *dst = getSequence(seq, b, 0);
-            T *src = getSequence(seq, b / beamSize, 0);
-            memcpy(dst, src, headNum * headSize * sizeof(T));
+        if (!kvTrans()) {
+            for (int b = batchSize - 1; b > 0; --b) {
+                T *dst = getSequence(seq, b, 0);
+                T *src = getSequence(seq, b / beamSize, 0);
+                memcpy(dst, src, sizeof(T) * headNum * headSize);
+            }
+        } else {
+            printf("Unsupported kv tensor optimization [ENABLE_KV_TRANS] in beam search for now.\n");
+            exit(-1);
         }
     }
-
-    // Below implementation could be a little faster (100.6 vs. 100.9), but also need to modify expand and reorder function
-
-    // // Get a vector for a specified sequence
-    // T *getSequence(int seqIdx, int batchIdx, int headIdx) {
-    //     return data + batchIdx * headNum * maxSeqLen * headSize + headIdx * maxSeqLen * headSize + seqIdx * headSize;
-    // }
-
-    // // Get a head matrix, return the start address and the stride
-    // std::pair<T *, int> getHead(int batchIdx, int headIdx) {
-    //     T *addr = data + batchIdx * headNum * maxSeqLen * headSize + headIdx * maxSeqLen * headSize;
-    //     return std::make_pair(addr, headSize);
-    // }
 
 private:
     int maxSeqLen;

--- a/src/models/env_config.cpp
+++ b/src/models/env_config.cpp
@@ -17,15 +17,44 @@
 #include <stdlib.h>
 
 bool enableCATMLP() {
+    // combine gate&up and calculate together, default enabled
     static int catMlp = -1;
-    if (catMlp == -1)
-        catMlp = (getenv("ENABLE_CAT_MLP") ? atoi(getenv("ENABLE_CAT_MLP")) : 1);
+    if (catMlp == -1) catMlp = (getenv("ENABLE_CAT_MLP") ? atoi(getenv("ENABLE_CAT_MLP")) : 1);
     return catMlp == 1;
 }
 
+bool tunedComm() {
+    // Tuning between shm and ccl reduceAdd methods to find the faster way, default enabled
+    static int tunedComm = -1;
+    if (tunedComm == -1) {
+        tunedComm = (getenv("ENABLE_TUNED_COMM") ? atoi(getenv("ENABLE_TUNED_COMM")) : 1);
+        if (tunedComm == 1) printf("ENABLE_TUNED_COMM is enabled for faster reduceAdd.\n");
+    }
+    return tunedComm == 1;
+}
+
 int getFlashThresh() {
+    // > threshold to enable flash attention, default 1024
     static int envFlashThresh = -1;
     if (envFlashThresh == -1)
         envFlashThresh = (getenv("FLASH_ATTN_THRESHOLD") ? atoi(getenv("FLASH_ATTN_THRESHOLD")) : 1024);
     return envFlashThresh;
+}
+
+bool enableSkipMsk() {
+    // Skip masked attn in flash attention for better perf of long sequence, default disabled
+    static int skipMsk = -1;
+    if (skipMsk == -1) {
+        skipMsk = (getenv("ENABLE_SKIP_MASK") ? atoi(getenv("ENABLE_SKIP_MASK")) : 0);
+        if (skipMsk == 1) printf("ENABLE_SKIP_MASK is enabled for ignoring mask Q*K.\n");
+    }
+    return skipMsk == 1;
+}
+
+bool kvTrans() {
+    // Transpose KV Tensor to [batchSize, headNum, seqLen, headSize] for better perf of long sequence, default disabled
+    // TODO: add support for reorder and expand when beam_search>1
+    static int kvTrans = -1;
+    if (kvTrans == -1) { kvTrans = (getenv("ENABLE_KV_TRANS") ? atoi(getenv("ENABLE_KV_TRANS")) : 0); }
+    return kvTrans == 1;
 }

--- a/src/utils/matmul_helper.h
+++ b/src/utils/matmul_helper.h
@@ -1067,7 +1067,7 @@ public:
             if constexpr (std::is_same_v<InT, bfloat16_t>) {
                 TimeLine t("onednn_amx_sgemm_f32bf16f32_compute_residential");
 #pragma omp parallel for collapse(2)
-                for (int i = 0; i < M; ++i) {
+                for (uint64_t i = 0; i < M; ++i) {
                     for (int j = 0; j < N; ++j) {
                         auto remain = N - j;
                         __mmask16 mask = (remain >= 16 ? 0xffff : (1 << remain) - 1);
@@ -1082,7 +1082,7 @@ public:
                 if (M > AMXThresholdM) {
                     TimeLine t("onednn_amx_sgemm_f32bf16f32_compute_residential");
 #pragma omp parallel for collapse(2)
-                    for (int i = 0; i < M; ++i) {
+                    for (uint64_t i = 0; i < M; ++i) {
                         for (int j = 0; j < N; ++j) {
                             res[i * ldres + j] = res[i * ldres + j] * gamma;
                         }
@@ -1624,7 +1624,7 @@ private:
         if (C == res) {
             scale_mem = memory(scale_md, *engine);
 #pragma omp parallel for
-            for (int i = 0; i < M; ++i) {
+            for (uint64_t i = 0; i < M; ++i) {
                 memcpy((Tin *)scale_mem.get_data_handle() + i * N, res + i * ldres, N * sizeof(Tin));
             }
         } else {

--- a/src/utils/messenger.h
+++ b/src/utils/messenger.h
@@ -18,13 +18,17 @@
 #include <cstdlib>
 #include <dlfcn.h>
 #include <iostream>
+#include <sys/time.h>
 
 #include "bfloat16.h"
 #include "compile_util.h"
 #include "oneapi/ccl.hpp"
 #include "shm_reduction.h"
+#include "simple_mem_pool.h"
 #include "timeline.h"
 #include "verbose.h"
+
+extern bool tunedComm();
 
 class Messenger {
 private:
@@ -97,35 +101,85 @@ public:
 
     int getColor() { return color; }
 
-    // From some example code of oneCCL, inplace reducing is supported
-    // Only float is used now
-    void reduceAdd(float *sendBuf, float *recvBuf, size_t count) {
+    template <typename T>
+    void reduceAdd(T *sendBuf, T *recvBuf, size_t count) {
         if (!check()) return;
         TimeLine t("Messenger.reduceAdd");
-
+        static std::unordered_map<size_t, int> tuned_map;
 #ifdef USE_SHM
-        if (count * sizeof(float) > pshm->getSHMSize() || !localRanksFlag) {
-            (*helperAllreduce)(sendBuf, recvBuf, count);
+        if (tunedComm() && localRanksFlag) {
+            size_t commSize = sizeof(T) * count;
+            if (sizeof(T) * count > pshm->getSHMSize()) { pshm->ShmResize(rank, commSize); }
+
+            auto it = tuned_map.find(commSize);
+            if (it == tuned_map.end()) {
+                T *commBuf = (T *)SimpleMemPool::instance().getBuffer("commBuf", commSize);
+                int warmup = 1, nruns = 3;
+                struct timeval start, end;
+                float dur_shm = std::numeric_limits<float>::max(), dur_ccl = std::numeric_limits<float>::max();
+                // tuned for the faster comm primitive
+                for (int i = 0; i < warmup + nruns; ++i) {
+                    if (i >= warmup) gettimeofday(&start, NULL);
+                    pshm->reduceAdd(commBuf, commBuf, count, rank, size);
+                }
+                gettimeofday(&end, NULL);
+                dur_shm = (end.tv_sec - start.tv_sec) * 1000 + (end.tv_usec - start.tv_usec) / 1000.0f;
+
+                if (commSize < 1.0e9) {
+                    for (int i = 0; i < warmup + nruns; ++i) {
+                        if (i >= warmup) gettimeofday(&start, NULL);
+                        cclAllreduce(commBuf, commBuf, count);
+                    }
+                    gettimeofday(&end, NULL);
+                    dur_ccl = (end.tv_sec - start.tv_sec) * 1000 + (end.tv_usec - start.tv_usec) / 1000.0f;
+                }
+
+                // default 0 means SHM Addreduce, 1 means CCL
+                int comm_type = 0;
+                if (rank == 0 && dur_ccl < dur_shm * 0.9) { comm_type = 1; }
+                this->broadcast(&comm_type, 1);
+                tuned_map[commSize] = comm_type;
+            }
+
+            if (tuned_map[commSize] == 0) {
+                pshm->reduceAdd(sendBuf, recvBuf, count, rank, size);
+            } else {
+                cclAllreduce(sendBuf, recvBuf, count);
+            }
         } else {
-            pshm->reduceAdd(sendBuf, recvBuf, count, rank, size);
+            reduceAddBase(sendBuf, recvBuf, count);
         }
 #else
-        (*helperAllreduce)(sendBuf, recvBuf, count);
+        reduceAddBase(sendBuf, recvBuf, count);
 #endif
     }
 
-    void reduceAdd(bfloat16_t *sendBuf, bfloat16_t *recvBuf, size_t count) {
+    // inplace reducing is supported
+    template <typename T>
+    void reduceAddBase(T *sendBuf, T *recvBuf, size_t count) {
         TimeLine t("Messenger.reduceAdd");
 
 #ifdef USE_SHM
-        if (count * sizeof(bfloat16_t) > pshm->getSHMSize() || !localRanksFlag) {
-            (*helperAllreduceBF16)(sendBuf, recvBuf, count);
+        if (sizeof(T) * count > pshm->getSHMSize() || !localRanksFlag) {
+            cclAllreduce(sendBuf, recvBuf, count);
         } else {
             pshm->reduceAdd(sendBuf, recvBuf, count, rank, size);
         }
 #else
-        (*helperAllreduceBF16)(sendBuf, recvBuf, count);
+        cclAllreduce(sendBuf, recvBuf, count);
 #endif
+    }
+
+    template <typename T>
+    void cclAllreduce(T *sendBuf, T *recvBuf, size_t count) {
+        if constexpr (std::is_same_v<T, bfloat16_t>) {
+            (*helperAllreduceBF16)(sendBuf, recvBuf, count);
+        } else if constexpr (std::is_same_v<T, float>) {
+            (*helperAllreduce)(sendBuf, recvBuf, count);
+        } else {
+            printf("Unsupported data type for reduceAdd.\n");
+            exit(-1);
+        }
     }
 
     // Only int is used now


### PR DESCRIPTION
Transpose KVCache with env var "ENABLE_KV_TRANS" for long sequence
Tune addreduce between shm and ccl for faster comm

| workload | baseline-2s | opt-2s |
| --------------- | --------------- | --------------- |
| llama-2-13b bs24 in512 bf16 (SPR+HBM) | 350ms | 90ms |
| llama-2-70b bs32 in4096 bf16 (SPR) | 1300ms | 640ms |