### PR TITLE
[Fix] Reduce convert memory usage.

### DIFF
--- a/src/xfastertransformer/tools/qwen_convert.py
+++ b/src/xfastertransformer/tools/qwen_convert.py
@@ -19,7 +19,9 @@ import numpy as np
 import os
 import torch
 
-from transformers import AutoModelForCausalLM
+from pathlib import Path
+
+from transformers import AutoModelForCausalLM, AutoConfig
 from transformers.generation import GenerationConfig
 
 from .convert import BaseModelConvert
@@ -114,13 +116,32 @@ class QwenConvert(BaseModelConvert):
         if not os.path.exists(saved_dir):
             os.makedirs(saved_dir)
 
+        from typing import TYPE_CHECKING, Any, Callable, ContextManager, Iterator, Sequence, TypeVar, cast
+
+        def _get_name_and_param(model_dir: Path):
+            num_parts = 82
+            for part_name in (f"model-{n:05}-of-{num_parts:05}.safetensors" for n in range(1, num_parts + 1)):
+                ctx: ContextManager[Any]
+                from safetensors import safe_open
+
+                ctx = cast(
+                    ContextManager[Any],
+                    safe_open(Path(model_dir) / part_name, framework="pt", device="cpu"),
+                )
+                with ctx as model_part:
+                    for name in model_part.keys():
+                        yield name, model_part.get_tensor(name)
+
         # load the model
         gen_config = GenerationConfig.from_pretrained(input_dir, trust_remote_code=True, resume_download=True)
-        model = AutoModelForCausalLM.from_pretrained(input_dir, device_map="auto", trust_remote_code=True)
+        hf_config, _ = AutoConfig.from_pretrained(
+            input_dir, return_unused_kwargs=True, trust_remote_code=True, fp16=True, use_flash_attn=False
+        )
 
-        hf_config = vars(model.config)
-
-        layer_names = [name for name, param in model.named_parameters()]
+        hf_config = {
+            **vars(hf_config),
+            **vars(gen_config),
+        }
 
         # save parameters to config file
         config = configparser.ConfigParser()
@@ -154,6 +175,7 @@ class QwenConvert(BaseModelConvert):
                 config.write(configfile)
         except Exception as e:
             print("Fail to save the config in config.ini.", str(e))
+            exit(-1)
 
         hf_model_name_pattern = [
             "ln_1.weight",
@@ -177,32 +199,17 @@ class QwenConvert(BaseModelConvert):
             "mlp.down_proj.weight",
         ]
 
-        state_dict = model.state_dict()
-        model_named_parameters = dict()
-        for name, param in state_dict.items():
-            # merge QKV
-            if "self_attn.q_proj.weight" in name:
-                k_name = name.replace("q_proj", "k_proj")
-                v_name = name.replace("q_proj", "v_proj")
-                qkv = torch.cat(
-                    (param.permute(1, 0), state_dict[k_name].permute(1, 0), state_dict[v_name].permute(1, 0)), dim=1
-                )
-                model_named_parameters[
-                    name.replace("self_attn.q_proj.weight", "attention.query_key_value.weight")
-                ] = qkv
-            # for merged weights, skip
-            elif "self_attn.k_proj.weight" in name or "self_attn.v_proj.weight" in name:
-                continue
-            elif "embed" in name:
-                model_named_parameters[name] = param
-            elif "lm_head" in name:
-                model_named_parameters[name] = param
-            else:
-                model_named_parameters[name] = param.permute(1, 0) if len(param.shape) == 2 else param
-
         print("Processing ...")
         pool = multiprocessing.Pool(processes)
-        for name, param in model_named_parameters.items():
+        for name, param in _get_name_and_param(input_dir):
+            param = param.half()
+            if "embed" in name or "lm_head" in name:
+                pass
+            else:
+                param = param.permute(1, 0) if len(param.shape) == 2 else param
+
+            # print(f"name = {name} param = {type(param)} {param.dtype} ")
+
             if name == "transformer.wte.weight":
                 if len(param.shape) == 2:
                     if param.shape[0] == hidden_size:
@@ -242,3 +249,5 @@ class QwenConvert(BaseModelConvert):
                 pool.starmap_async(self.split_and_convert_process, starmap_args)
         pool.close()
         pool.join()
+
+        print(f"{saved_dir} export successful!")


### PR DESCRIPTION
The current Qwen-72B model conversion process consumes approximately 282GB of memory, which far exceeds the configuration of the machines currently used by the client. This PR modify the conversion method to reduce memory usage to around 20~30GB.