### PR TITLE
[example] add gemma model support with example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ xFasterTransformer provides a series of APIs, both of C++ and Python, for end us
 | SecLLM(YaRN-Llama) | &#10004;  | &#10004; |   &#10004;   |
 |        Opt         | &#10004;  | &#10004; |   &#10004;   |
 |   Deepseek-coder   | &#10004;  | &#10004; |   &#10004;   |
+|      gemma         | &#10004;  | &#10004; |   &#10004;   |
+|     gemma-1.1      | &#10004;  | &#10004; |   &#10004;   |
+|     codegemma      | &#10004;  | &#10004; |   &#10004;   |
 
 ### DataType support list
 

--- a/examples/cpp/example.cpp
+++ b/examples/cpp/example.cpp
@@ -258,6 +258,15 @@ private:
     const char **vocab_list = vocab_qwen;
 };
 
+class GemmaTokenizer : public TokenizerBase {
+public:
+    GemmaTokenizer(std::string &tokenPath) : TokenizerBase(tokenPath) {
+        vocabSize = 256000;
+        prefixTokenIds = {2, 2, 106, 1645, 108};
+        suffixTokenIds = {107, 108, 106, 2516, 108};
+    }
+};
+
 TokenizerBase *getTokenizer(std::string &modeltype, std::string &tokenPath) {
     if (modeltype == "gpt") {
         return new OptTokenizer(tokenPath);
@@ -273,6 +282,8 @@ TokenizerBase *getTokenizer(std::string &modeltype, std::string &tokenPath) {
         return new ChatGLM2Tokenizer(tokenPath);
     } else if (modeltype == "qwen") {
         return new QwenTokenizer(tokenPath);
+    } else if (modeltype == "gemma") {
+        return new GemmaTokenizer(tokenPath);
     } else {
         std::cout << "[Error] Token list of loaded model is unsupported yet.\n" << std::endl;
         exit(-1);


### PR DESCRIPTION
1. add gemma model into example.cpp;
2. Verified the Gemma series models, including CodeGemma, Gemma1.1, and Gemma. Due to the same structure, all three models are supported, and they have been validated in examples and web demos. Currently, the test routines for these models are consistent with Gemma.
https://huggingface.co/collections/google/codegemma-release-66152ac7b683e2667abdee11
https://huggingface.co/collections/google/gemma-release-65d5efbccdbb8c4202ec078b