### PR TITLE
[CMake] Add oneccl build depends for comm_helper.

### DIFF
--- a/src/comm_helper/CMakeLists.txt
+++ b/src/comm_helper/CMakeLists.txt
@@ -18,3 +18,7 @@ aux_source_directory(${CMAKE_CURRENT_SOURCE_DIR} COMM_HELPER_SRCS)
 add_library(xft_comm_helper SHARED ${COMM_HELPER_SRCS})
 
 target_link_libraries(xft_comm_helper ${MPI_LIBS} ccl)
+
+if(NOT MPI_FOUND OR NOT oneCCL_FOUND)
+    add_dependencies(xft_comm_helper oneccl)
+endif()


### PR DESCRIPTION
Fix build issue in no oneccl environment.