### PR TITLE
[Python] Add `get_env()` to get LD_PRELOAD set.

### DIFF
--- a/src/pytorch/CMakeLists.txt
+++ b/src/pytorch/CMakeLists.txt
@@ -57,3 +57,10 @@ add_custom_command(TARGET xfastertransformer_pt POST_BUILD
     ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     COMMENT "Copying libxft_comm_helper.so to src/xfastertransformer directory"
 )
+
+add_custom_command(TARGET xfastertransformer_pt POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_SOURCE_DIR}/3rdparty/mklml/lib/libiomp5.so"
+    ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    COMMENT "Copying libiomp5.so to src/xfastertransformer directory"
+)

--- a/src/xfastertransformer/__init__.py
+++ b/src/xfastertransformer/__init__.py
@@ -46,6 +46,7 @@ _import_structure = {
         "YaRNLlamaConvert",
         "DeepseekConvert",
     ],
+    "env": ["get_env"],
 }
 
 if TYPE_CHECKING:
@@ -61,6 +62,7 @@ if TYPE_CHECKING:
     from .tools import QwenConvert
     from .tools import Qwen2Convert
     from .tools import YaRNLlamaConvert
+    from .env import get_env
 else:
     # This LazyImportModule is refer to optuna.integration._IntegrationModule
     # Source code url https://github.com/optuna/optuna/blob/master/optuna/integration/__init__.py

--- a/src/xfastertransformer/env.py
+++ b/src/xfastertransformer/env.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2023-2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+import os
+def get_env():
+    libiomp_path = os.path.dirname(os.path.abspath(__file__)) + "/libxft_comm_helper.so"
+    env = f"LD_PRELOAD={libiomp_path}:\$LD_PRELOAD"
+    return env


### PR DESCRIPTION
libiomp can be set by `export $(python -c 'import xfastertransformer as xft; print(xft.get_env())')`