### PR TITLE
build: update pyproject.toml cmake<4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 line-length = 120
 target-version = ["py38", "py39", "py310", "py311"]
 [build-system]
-requires = ["setuptools", "cmake"]
+requires = ["setuptools", "cmake<4.0"]


### PR DESCRIPTION
Build fails.
```
$ pip install . -v
  Collecting cmake
    Using cached https://mirror.nju.edu.cn/pypi/web/packages/91/96/2671d7f3612c4449affc956542b25d9193efd8026dbc8ab6b3498f5cede3/cmake-4.0.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (27.9 MB)
...
  CMake Error at CMakeLists.txt:15 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.

    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.

    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
  make[2]: *** [examples/cpp/CMakeFiles/sentencepiece_lib.dir/build.make:93: examples/cpp/sentencepiece_lib-prefix/src/sentencepiece_lib-stamp/sentencepiece_lib-configure] Error 1
  make[2]: Leaving directory '/home/ctp/xFasterTransformer/build'
  make[1]: *** [CMakeFiles/Makefile2:669: examples/cpp/CMakeFiles/sentencepiece_lib.dir/all] Error 2
  make[1]: *** Waiting for unfinished jobs....
```